### PR TITLE
CBBF-119: Consolidated the set provider number calls from HHA, Hospic…

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformer.java
@@ -65,7 +65,15 @@ final class DMEClaimTransformer {
 				.setCoverage(TransformerUtils.referenceCoverage(claimGroup.getBeneficiaryId(), MedicareSegment.PART_B));
 		eob.setPatient(TransformerUtils.referencePatient(claimGroup.getBeneficiaryId()));
 		eob.setStatus(ExplanationOfBenefitStatus.ACTIVE);
-
+		
+		/*
+		 * TODO: DME does not have a provider number at the EOB level to map to but has
+		 * provider billing numbers at the claim line level. Need to do some research on
+		 * how this should be mapped, if it even can be, like the other claim types:
+		 * 
+		 * TransformerUtils.setProviderNumber(eob, claimGroup.getProviderNumber());
+		 */
+		
 		if (claimGroup.getClinicalTrialNumber().isPresent()) {
 			/*
 			 * FIXME this should be mapped as an extension valueIdentifier

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HHAClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HHAClaimTransformer.java
@@ -73,8 +73,8 @@ final class HHAClaimTransformer {
 		TransformerUtils.setPeriodStart(eob.getBillablePeriod(), claimGroup.getDateFrom());
 		TransformerUtils.setPeriodEnd(eob.getBillablePeriod(), claimGroup.getDateThrough());
 
-		eob.setProvider(TransformerUtils.createIdentifierReference(TransformerConstants.IDENTIFIER_CMS_PROVIDER_NUMBER,
-				claimGroup.getProviderNumber()));
+		// set the provider number which is common among several claim types
+		TransformerUtils.setProviderNumber(eob, claimGroup.getProviderNumber());
 
 		if (claimGroup.getClaimNonPaymentReasonCode().isPresent()) {
 			TransformerUtils.addExtensionCoding(eob, TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HospiceClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HospiceClaimTransformer.java
@@ -75,8 +75,8 @@ final class HospiceClaimTransformer {
 		TransformerUtils.setPeriodStart(eob.getBillablePeriod(), claimGroup.getDateFrom());
 		TransformerUtils.setPeriodEnd(eob.getBillablePeriod(), claimGroup.getDateThrough());
 
-		eob.setProvider(TransformerUtils.createIdentifierReference(TransformerConstants.IDENTIFIER_CMS_PROVIDER_NUMBER,
-				claimGroup.getProviderNumber()));
+		// set the provider number which is common among several claim types
+		TransformerUtils.setProviderNumber(eob, claimGroup.getProviderNumber());
 
 		if (claimGroup.getClaimNonPaymentReasonCode().isPresent()) {
 			TransformerUtils.addExtensionCoding(eob, TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/InpatientClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/InpatientClaimTransformer.java
@@ -77,6 +77,9 @@ final class InpatientClaimTransformer {
 		TransformerUtils.addExtensionCoding(eob.getBillablePeriod(), TransformerConstants.EXTENSION_CODING_CLAIM_QUERY,
 				TransformerConstants.EXTENSION_CODING_CLAIM_QUERY, String.valueOf(claimGroup.getClaimQueryCode()));
 
+		// set the provider number which is common among several claim types
+		TransformerUtils.setProviderNumber(eob, claimGroup.getProviderNumber());
+		
 		if (claimGroup.getClaimNonPaymentReasonCode().isPresent()) {
 			TransformerUtils.addExtensionCoding(eob, TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON,
 					TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/OutpatientClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/OutpatientClaimTransformer.java
@@ -74,8 +74,8 @@ final class OutpatientClaimTransformer {
 				TransformerConstants.EXTENSION_CODING_CLAIM_QUERY,
 				String.valueOf(claimGroup.getClaimQueryCode()));
 
-		eob.setProvider(TransformerUtils.createIdentifierReference(TransformerConstants.IDENTIFIER_CMS_PROVIDER_NUMBER,
-				claimGroup.getProviderNumber()));
+		// set the provider number which is common among several claim types
+		TransformerUtils.setProviderNumber(eob, claimGroup.getProviderNumber());
 
 		if (claimGroup.getClaimNonPaymentReasonCode().isPresent()) {
 			TransformerUtils.addExtensionCoding(eob, TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/SNFClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/SNFClaimTransformer.java
@@ -76,8 +76,8 @@ final class SNFClaimTransformer {
 		TransformerUtils.addExtensionCoding(eob.getBillablePeriod(), TransformerConstants.EXTENSION_CODING_CLAIM_QUERY,
 				TransformerConstants.EXTENSION_CODING_CLAIM_QUERY, String.valueOf(claimGroup.getClaimQueryCode()));
 
-		eob.setProvider(TransformerUtils.createIdentifierReference(TransformerConstants.IDENTIFIER_CMS_PROVIDER_NUMBER,
-				claimGroup.getProviderNumber()));
+		// set the provider number which is common among several claim types
+		TransformerUtils.setProviderNumber(eob, claimGroup.getProviderNumber());
 
 		if (claimGroup.getClaimNonPaymentReasonCode().isPresent()) {
 			TransformerUtils.addExtensionCoding(eob, TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
@@ -856,4 +856,18 @@ public final class TransformerUtils {
 		return item;
 	}
 
+	/**
+	 * Sets the provider number field which is common among these claim types:
+	 * Inpatient, Outpatient, Hospice, HHA and SNF.
+	 * 
+	 * @param eob
+	 *            the {@link ExplanationOfBenefit} this method will modify
+	 * @param providerNumber
+	 *            a {@link String} PRVDR_NUM: representing the provider number for
+	 *            the claim
+	 */
+	static void setProviderNumber(ExplanationOfBenefit eob, String providerNumber) {
+		eob.setProvider(TransformerUtils.createIdentifierReference(TransformerConstants.IDENTIFIER_CMS_PROVIDER_NUMBER,
+				providerNumber));
+	}
 }

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformerTest.java
@@ -80,6 +80,14 @@ public final class DMEClaimTransformerTest {
 		TransformerTestUtils.assertDateEquals(claim.getDateFrom(), eob.getBillablePeriod().getStartElement());
 		TransformerTestUtils.assertDateEquals(claim.getDateThrough(), eob.getBillablePeriod().getEndElement());
 
+		/*
+		 * TODO: DME does not have a provider number at the EOB level to map to but has
+		 * provider billing numbers at the claim line level. Need to do some research on
+		 * how this should be mapped, if it even can be, like the other claim types:
+		 * 
+		 * TransformerTestUtils.assertProviderNumber(eob, claimGroup.getProviderNumber());
+		 */
+		
 		Assert.assertEquals(TransformerConstants.CODED_EOB_DISPOSITION, eob.getDisposition());
 
 		// Test to ensure common group fields between Carrier and DME match

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HHAClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HHAClaimTransformerTest.java
@@ -79,8 +79,8 @@ public final class HHAClaimTransformerTest {
 		TransformerTestUtils.assertDateEquals(claim.getDateFrom(), eob.getBillablePeriod().getStartElement());
 		TransformerTestUtils.assertDateEquals(claim.getDateThrough(), eob.getBillablePeriod().getEndElement());
 
-		TransformerTestUtils.assertReferenceIdentifierEquals(TransformerConstants.IDENTIFIER_CMS_PROVIDER_NUMBER, claim.getProviderNumber(),
-				eob.getProvider());
+		// test the common field provider number is set as expected in the EOB
+		TransformerTestUtils.assertProviderNumber(eob, claim.getProviderNumber());
 
 		TransformerTestUtils.assertExtensionCodingEquals(eob, TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON,
 				TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON, claim.getClaimNonPaymentReasonCode().get());

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HospiceClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HospiceClaimTransformerTest.java
@@ -77,8 +77,8 @@ public final class HospiceClaimTransformerTest {
 		TransformerTestUtils.assertDateEquals(claim.getDateFrom(), eob.getBillablePeriod().getStartElement());
 		TransformerTestUtils.assertDateEquals(claim.getDateThrough(), eob.getBillablePeriod().getEndElement());
 
-		TransformerTestUtils.assertReferenceIdentifierEquals(TransformerConstants.IDENTIFIER_CMS_PROVIDER_NUMBER,
-				claim.getProviderNumber(), eob.getProvider());
+		// test the common field provider number is set as expected in the EOB
+		TransformerTestUtils.assertProviderNumber(eob, claim.getProviderNumber());
 
 		TransformerTestUtils.assertExtensionCodingEquals(eob,
 				TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON,

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/InpatientClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/InpatientClaimTransformerTest.java
@@ -79,6 +79,9 @@ public final class InpatientClaimTransformerTest {
 		TransformerTestUtils.assertDateEquals(claim.getDateFrom(), eob.getBillablePeriod().getStartElement());
 		TransformerTestUtils.assertDateEquals(claim.getDateThrough(), eob.getBillablePeriod().getEndElement());
 
+		// test the common field provider number is set as expected in the EOB
+		TransformerTestUtils.assertProviderNumber(eob, claim.getProviderNumber());
+		
 		TransformerTestUtils.assertExtensionCodingEquals(eob.getBillablePeriod(), TransformerConstants.EXTENSION_CODING_CLAIM_QUERY,
 				TransformerConstants.EXTENSION_CODING_CLAIM_QUERY, String.valueOf(claim.getClaimQueryCode()));
 

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/OutpatientClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/OutpatientClaimTransformerTest.java
@@ -88,6 +88,9 @@ public final class OutpatientClaimTransformerTest {
 				TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON,
 				claim.getClaimNonPaymentReasonCode().get());
 
+		// test the common field provider number is set as expected in the EOB
+		TransformerTestUtils.assertProviderNumber(eob, claim.getProviderNumber());
+		
 		Assert.assertEquals(claim.getPaymentAmount(), eob.getPayment().getAmount().getValue());
 
 		Assert.assertEquals(claim.getTotalChargeAmount(), eob.getTotalCost().getValue());

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/SNFClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/SNFClaimTransformerTest.java
@@ -84,8 +84,9 @@ public final class SNFClaimTransformerTest {
 				TransformerConstants.EXTENSION_CODING_CLAIM_QUERY, TransformerConstants.EXTENSION_CODING_CLAIM_QUERY,
 				String.valueOf(claim.getClaimQueryCode()));
 
-		TransformerTestUtils.assertReferenceIdentifierEquals(TransformerConstants.IDENTIFIER_CMS_PROVIDER_NUMBER,
-				claim.getProviderNumber(), eob.getProvider());
+		// test the common field provider number is set as expected in the EOB
+		TransformerTestUtils.assertProviderNumber(eob, claim.getProviderNumber());
+		
 		TransformerTestUtils.assertExtensionCodingEquals(eob,
 				TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON,
 				TransformerConstants.EXTENSION_CODING_CCW_PAYMENT_DENIAL_REASON,

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerTestUtils.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerTestUtils.java
@@ -763,4 +763,19 @@ final class TransformerTestUtils {
 		assertExtensionCodingEquals(item, TransformerConstants.CODING_NDC, TransformerConstants.CODING_NDC,
 				nationalDrugCode.get());
 	}
+	
+	/**
+	 * Tests the provider number field is set as expected in the EOB. This field is
+	 * common among these claim types: Inpatient, Outpatient, Hospice, HHA and SNF.
+	 * 
+	 * @param eob
+	 *            the {@link ExplanationOfBenefit} this method will test against
+	 * @param providerNumber
+	 *            a {@link String} PRVDR_NUM: representing the expected provider
+	 *            number for the claim
+	 */
+	static void assertProviderNumber(ExplanationOfBenefit eob, String providerNumber) {
+		assertReferenceIdentifierEquals(TransformerConstants.IDENTIFIER_CMS_PROVIDER_NUMBER,
+				providerNumber, eob.getProvider());
+	}
 }


### PR DESCRIPTION
…e, Inpatient, Outpatient and SNF claim types into a single method located in TransforerUtils.  Also updated corresponding tests.  Since DME does not have a provider number at the group level, a TODO comment was added in the relevant code and test sections to research how this is to be handled for that specific claim type.