### PR TITLE
CBBI-289: Updated the Jenkinsfile for new Jenkins server.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,60 +1,66 @@
 /**
  * <p>
  * This is the script that will be run by Jenkins to build and test this 
- * project. This drives the project's continuous integration, delivery, and
- * deployment.
+ * project. This drives the project's continuous integration and delivery.
  * </p>
  * <p>
- * This script is run by Jenkins' 
- * <a href="https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Plugin">Pipeline Plugin</a>. 
- * A good intro tutorial for working with this plugin can be found here: 
- * <a href="https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md">jenkinsci/pipeline-plugin/TUTORIAL.md</a>.
+ * This script is run by Jenkins' Pipeline feature. A good intro tutorial for
+ * working with Jenkins Pipelines can be found here:
+ * <a href="https://jenkins.io/doc/book/pipeline/">Jenkins > Pipeline</a>.
  * </p>
  * <p>
  * The canonical Jenkins server job for this project is located here: 
- * <a href="http://builds.hhsdevcloud.us/job/HHSIDEAlab/job/bluebutton-server/">bluebutton-server</a>.
+ * <a href="https://builds.ls.r53.cmsfhir.systems/jenkins/job/bluebutton-data-server">bluebutton-data-server</a>.
  * </p>
  */
 
 node {
-	stage 'Checkout'
+	stage('Checkout') {
+		// Grab the commit that triggered the build.
 		checkout scm
+
+		// Update the POM version so that the artifacts produced by this build
+		// are distinguishable from other builds.
 		setPomVersionUsingBuildId()
-	
-	stage 'Build'
-		/* Create the settings file for Maven (contains deploy credentials). 
-		 * Will be automatically cleaned up at end of block.
-		 */
-		wrap([$class: 'ConfigFileBuildWrapper', 
-			managedFiles: [[fileId: 'org.jenkinsci.plugins.configfiles.maven.MavenSettingsConfig:cms-bluebutton-settings-xml', 
-			variable: 'SETTINGS_PATH']]
-		]) {
-			// Run the build...
-			mvn "--settings ${env.SETTINGS_PATH} -Dmaven.test.failure.ignore -Prun-its-with-db-on-disk clean deploy scm:tag"
-		}
-	
-	stage 'Archive'
-		step([$class: 'ArtifactArchiver', artifacts: '**/target/*.jar', fingerprint: true, allowEmptyArchive: true])
-		step([$class: 'ArtifactArchiver', artifacts: '**/target/*.war', fingerprint: true, allowEmptyArchive: true])
-		step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml', allowEmptyResults: true])
-		step([$class: 'JUnitResultArchiver', testResults: '**/target/failsafe-reports/TEST-*.xml', allowEmptyResults: true])
-		
-	stage 'Trigger Downstream'
-		//build job: '../some-other-project/master', wait: false
+	}
+
+	stage('Build') {
+		mvn "--update-snapshots -Dmaven.test.failure.ignore clean install"
+	}
+
+	stage('Archive') {
+		// Fingerprint the output artifacts and archive the test results.
+		// (Archiving the artifacts here would waste space, as the build
+		// deploys them to the local Maven repository.)
+		fingerprint '**/target/*.jar'
+		fingerprint '**/target/*.war'
+		junit testResults: '**/target/*-reports/TEST-*.xml', keepLongStdio: true
+		archiveArtifacts artifacts: '**/target/*-reports/*.txt', allowEmptyArchive: true
+	}
 }
 
 /**
  * Runs Maven with the specified arguments.
- * 
+ *
  * @param args the arguments to pass to <code>mvn</code>
  */
 def mvn(args) {
 	// This tool must be setup and named correctly in the Jenkins config.
-    sh "${tool 'maven-3'}/bin/mvn ${args}"
+	def mvnHome = tool 'maven-3'
+
+	// Run the build, using Maven, with the appropriate config.
+	configFileProvider(
+			[
+				configFile(fileId: 'bluebutton:settings.xml', variable: 'MAVEN_SETTINGS'),
+				configFile(fileId: 'bluebutton:toolchains.xml', variable: 'MAVEN_TOOLCHAINS')
+			]
+	) {
+		sh "${mvnHome}/bin/mvn --settings $MAVEN_SETTINGS --toolchains $MAVEN_TOOLCHAINS ${args}"
+	}
 }
 
 /**
- * @return the <version /> from the POM of the project in the current working 
+ * @return the <version /> from the POM of the project in the current working
  *         directory.
  */
 def readPomVersion() {
@@ -62,26 +68,20 @@ def readPomVersion() {
 	mvn "--quiet --non-recursive -Dexec.executable='echo' -Dexec.args='\${project.version}' org.codehaus.mojo:exec-maven-plugin:1.3.1:exec > pom.project.version.txt"
 	pomProjectVersion = readFile('pom.project.version.txt').trim()
 	sh "rm -f pom.project.version.txt"
-	
+
 	echo "Current POM version: ${pomProjectVersion}"
 	return pomProjectVersion
 }
 
 /**
- * @return an ID for the current build, in the form of 
- *         "<code>${env.BUILD_NUMBER}</code>" for builds against the SCM's 
- *         <code>master</code> branch, and 
- *         "<code>${env.BRANCH_NAME}-${env.BUILD_NUMBER}</code>" for other branches
+ * @return an ID for the current build, in the form of
+ *         "<code>${env.BRANCH_NAME}-${env.BUILD_NUMBER}</code>"
  */
 def calculateBuildId() {
-	// Calculate the build ID.
 	gitBranchName = "${env.BRANCH_NAME}".toString()
-	buildId = ""
-	if("master".equals(gitBranchName)) {
-		buildId = "${env.BUILD_NUMBER}"
-	} else {
-		buildId = "${gitBranchName}-${env.BUILD_NUMBER}"
-	}
+	gitCommitId = sh(script: "git rev-parse HEAD", returnStdout: true).trim()
+
+	buildId = "${gitBranchName}-${gitCommitId}"
 
 	echo "Build ID: ${buildId} (for branch ${gitBranchName})"
 	return buildId
@@ -89,19 +89,30 @@ def calculateBuildId() {
 
 /**
  * <p>
- * Uses <code>org.codehaus.mojo:versions-maven-plugin</code> to set the version
- * of the POM in the current working directory, such that it replaces 
- * "<code>SNAPSHOT</code>" with the value of {@link #calculateBuildId()}.
+ * The same artifact repository will store builds produced from all source code
+ * branches. Unfortunately, Maven's versioning scheme doesn't really account
+ * for branches: unless the version numbers are manually changed for each
+ * branch (and there isn't any graceful scheme that would accommodate that),
+ * the "latest <code>-SNAPSHOT</code>" artifact included in builds could be
+ * from any branch.
  * </p>
  * <p>
- * This ensures that every CI build has a continuous-deployment-friendly, 
- * unique version number.
+ * This method is used to workaround that problem. For non-<code>master</code>
+ * branch builds, the "<code>-SNAPSHOT</code> version qualifier is replaced
+ * with "<code>-&lt;branchName&gt;-&lt;commitSha1&gt;</code>, ensuring that
+ * those builds don't "pollute" the <code>master</code> branch's artifact
+ * history. Version numbers for <code>master</code> branch builds are left
+ * alone.
  * </p>
  */
 def setPomVersionUsingBuildId() {
-	// Update the POM version to include the build ID.
-	// Reference: https://maven.apache.org/maven-release/maven-release-plugin/examples/update-versions.html
-	pomProjectVersionWithBuildId = readPomVersion().replaceAll("SNAPSHOT", calculateBuildId())
-	mvn "--batch-mode --quiet org.codehaus.mojo:versions-maven-plugin:2.2:set -DnewVersion='${pomProjectVersionWithBuildId}' -DgenerateBackupPoms=false"
-	echo "Updated POM version: ${pomProjectVersionWithBuildId}"
+	gitBranchName = "${env.BRANCH_NAME}".toString()
+	if (!"master".equals(gitBranchName)) {
+		pomProjectVersionWithBuildId = readPomVersion().replaceAll("SNAPSHOT", calculateBuildId())
+
+		// Update the POM version to include the build ID.
+		// Reference: https://maven.apache.org/maven-release/maven-release-plugin/examples/update-versions.html
+		mvn "--batch-mode --quiet org.codehaus.mojo:versions-maven-plugin:2.2:set -DnewVersion='${pomProjectVersionWithBuildId}' -DgenerateBackupPoms=false"
+		echo "Updated POM version: ${pomProjectVersionWithBuildId}"
+	}
 }

--- a/bluebutton-server-app/pom.xml
+++ b/bluebutton-server-app/pom.xml
@@ -16,7 +16,7 @@
 	</description>
 
 	<properties>
-		<hapi-fhir.version>2.4.0-PR660</hapi-fhir.version>
+		<hapi-fhir.version>2.5</hapi-fhir.version>
 		<jersey.version>2.25.1</jersey.version>
 	</properties>
 

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
@@ -36,6 +36,7 @@ import com.codahale.metrics.MetricRegistry;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.IGenericClient;
+import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.RifFileEvent;
 import gov.hhs.cms.bluebutton.data.model.rif.RifFileRecords;
@@ -123,6 +124,20 @@ public final class ServerTestUtils {
 		ctx.getRestfulClientFactory().setHttpClient(httpClient);
 
 		IGenericClient client = ctx.newRestfulGenericClient(TEST_SERVER_URL_BASE);
+
+		/*
+		 * The FHIR client logging (for tests) can be managed via the
+		 * `src/test/resources/logback-test.xml` file.
+		 */
+		LoggingInterceptor loggingInterceptor = new LoggingInterceptor();
+		loggingInterceptor.setLogRequestSummary(LOGGER.isDebugEnabled());
+		loggingInterceptor.setLogResponseSummary(LOGGER.isDebugEnabled());
+		loggingInterceptor.setLogRequestHeaders(LOGGER.isTraceEnabled());
+		loggingInterceptor.setLogResponseHeaders(LOGGER.isTraceEnabled());
+		loggingInterceptor.setLogRequestBody(LOGGER.isTraceEnabled());
+		loggingInterceptor.setLogResponseBody(LOGGER.isTraceEnabled());
+		client.registerInterceptor(loggingInterceptor);
+
 		return client;
 	}
 

--- a/bluebutton-server-app/src/test/resources/logback-test.xml
+++ b/bluebutton-server-app/src/test/resources/logback-test.xml
@@ -8,6 +8,10 @@
 			<pattern>%date{ISO8601} [%thread] %-5level %logger{36} [%file:%line] %msg%n</pattern>
 		</encoder>
 	</appender>
+	
+	<!-- Set to 'debug' to log FHIR test client request and response summaries,
+		or to 'trace' to log the full requests and responses. -->
+	<logger name="gov.hhs.cms.bluebutton.server.app.ServerTestUtils" level="info" />
 
 	<root level="info">
 		<appender-ref ref="STDOUT" />


### PR DESCRIPTION
Some functional changes here:

* For now, run `mvn install` instead of `mvn deploy`. Will switch if/when a Nexus server is available.
* Only change versions for non-master builds.
* Archive the things that matter, but not binaries, as that's a duplicate waste of space. Do fingerprint binaries, though.

https://issues.hhsdevcloud.us/browse/CBBI-289