### PR TITLE
CBBF-117: Added a common method to TransformerUtils that sets the hcp…

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CarrierClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CarrierClaimTransformer.java
@@ -158,14 +158,10 @@ final class CarrierClaimTransformer {
 				item.setService(TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
 						"" + claimGroup.getHcpcsYearCode().get(), claimLine.getHcpcsCode().get()));
 			}
-			if (claimLine.getHcpcsInitialModifierCode().isPresent()) {
-				item.addModifier(TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
-						"" + claimGroup.getHcpcsYearCode().get(), claimLine.getHcpcsInitialModifierCode().get()));
-			}
-			if (claimLine.getHcpcsSecondModifierCode().isPresent()) {
-				item.addModifier(TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
-						"" + claimGroup.getHcpcsYearCode().get(), claimLine.getHcpcsSecondModifierCode().get()));
-			}
+			
+			// set hcpcs modifier codes for the claim
+			TransformerUtils.setHcpcsModifierCodes(item, claimLine.getHcpcsInitialModifierCode(),
+					claimLine.getHcpcsSecondModifierCode(), claimGroup.getHcpcsYearCode());
 
 			if (claimLine.getMtusCode().isPresent()) {
 				TransformerUtils.addExtensionCoding(item, TransformerConstants.EXTENSION_CODING_MTUS,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformer.java
@@ -174,16 +174,9 @@ final class DMEClaimTransformer {
 				item.setService(TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
 						"" + claimGroup.getHcpcsYearCode().get(), claimLine.getHcpcsCode().get()));
 			}
-			if (claimLine.getHcpcsInitialModifierCode().isPresent()) {
-				item.addModifier(TransformerUtils.createCodeableConcept(
-						TransformerConstants.CODING_HCPCS, "" + claimGroup.getHcpcsYearCode().get(),
-						claimLine.getHcpcsInitialModifierCode().get()));
-			}
-			if (claimLine.getHcpcsSecondModifierCode().isPresent()) {
-				item.addModifier(TransformerUtils.createCodeableConcept(
-						TransformerConstants.CODING_HCPCS, "" + claimGroup.getHcpcsYearCode().get(),
-						claimLine.getHcpcsSecondModifierCode().get()));
-			}
+			// set hcpcs modifier codes for the claim
+			TransformerUtils.setHcpcsModifierCodes(item, claimLine.getHcpcsInitialModifierCode(),
+					claimLine.getHcpcsSecondModifierCode(), claimGroup.getHcpcsYearCode());
 
 			item.addAdjudication()
 					.setCategory(

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HHAClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HHAClaimTransformer.java
@@ -189,17 +189,9 @@ final class HHAClaimTransformer {
 					.setCode(TransformerConstants.CODED_MONEY_USD)
 					.setValue(claimLine.getPaymentAmount());
 
-			if (claimLine.getHcpcsInitialModifierCode().isPresent()) {
-				item.addModifier(
-						TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
-								claimLine.getHcpcsInitialModifierCode().get()));
-			}
-
-			if (claimLine.getHcpcsSecondModifierCode().isPresent()) {
-				item.addModifier(
-						TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
-								claimLine.getHcpcsSecondModifierCode().get()));
-			}
+			// set hcpcs modifier codes for the claim
+			TransformerUtils.setHcpcsModifierCodes(item, claimLine.getHcpcsInitialModifierCode(),
+					claimLine.getHcpcsSecondModifierCode(), Optional.empty());
 
 			// Common item level fields between Inpatient, Outpatient, HHA, Hospice and SNF
 			TransformerUtils.mapEobCommonItemRevenue(item, eob, claimLine.getRevenueCenterCode(),

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HospiceClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HospiceClaimTransformer.java
@@ -171,16 +171,9 @@ final class HospiceClaimTransformer {
 
 			item.setLocation(new Address().setState((claimGroup.getProviderStateCode())));
 
-			if (claimLine.getHcpcsInitialModifierCode().isPresent()) {
-				item.addModifier(
-						TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
-								claimLine.getHcpcsInitialModifierCode().get()));
-			}
-			if (claimLine.getHcpcsSecondModifierCode().isPresent()) {
-				item.addModifier(
-						TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
-								claimLine.getHcpcsSecondModifierCode().get()));
-			}
+			// set hcpcs modifier codes for the claim
+			TransformerUtils.setHcpcsModifierCodes(item, claimLine.getHcpcsInitialModifierCode(),
+					claimLine.getHcpcsSecondModifierCode(), Optional.empty());
 
 			TransformerUtils.addExtensionCoding(item, TransformerConstants.CODING_FHIR_ACT_INVOICE_GROUP,
 					TransformerConstants.CODING_FHIR_ACT_INVOICE_GROUP,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/OutpatientClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/OutpatientClaimTransformer.java
@@ -295,16 +295,9 @@ final class OutpatientClaimTransformer {
 						TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
 								claimLine.getHcpcsCode().get()));
 			}
-			if (claimLine.getHcpcsInitialModifierCode().isPresent()) {
-				item.addModifier(
-						TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
-								claimLine.getHcpcsInitialModifierCode().get()));
-			}
-			if (claimLine.getHcpcsSecondModifierCode().isPresent()) {
-				item.addModifier(
-						TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
-								claimLine.getHcpcsSecondModifierCode().get()));
-			}
+			// set hcpcs modifier codes for the claim
+			TransformerUtils.setHcpcsModifierCodes(item, claimLine.getHcpcsInitialModifierCode(),
+					claimLine.getHcpcsSecondModifierCode(), Optional.empty());
 
 			item.addAdjudication()
 					.setCategory(

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
@@ -1760,5 +1760,46 @@ public final class TransformerUtils {
 		eob.setProvider(TransformerUtils.createIdentifierReference(TransformerConstants.IDENTIFIER_CMS_PROVIDER_NUMBER,
 				providerNumber));
 	}
+	
+	/**
+	 * Sets the hcpcs related fields which are common among these claim types:
+	 * Carrier, Outpatient, DME, Hospice and HHA
+	 *
+	 * @param item
+	 *            the {@link ItemComponent} this method will modify
+	 * @param hcpcsInitialModifierCode
+	 *            the {@link Optional}&lt;{@link String}&gt; HCPCS_1ST_MDFR_CD:
+	 *            representing the hcpcs initial modifier code for the claim
+	 * @param hcpcsSecondModifierCode
+	 *            the {@link Optional}&lt;{@link String}&gt; HCPCS_2ND_MDFR_CD:
+	 *            representing the hcpcs second modifier code for the claim
+	 * @param hcpcsYearCode
+	 *            the {@link Optional}&lt;{@link Character}&gt;
+	 *            CARR_CLM_HCPCS_YR_CD: representing the hcpcs year code for the
+	 *            claim
+	 */
+	static void setHcpcsModifierCodes(ItemComponent item, Optional<String> hcpcsInitialModifierCode,
+			Optional<String> hcpcsSecondModifierCode, Optional<Character> hcpcsYearCode) {
+		if (hcpcsYearCode.isPresent()) { // some claim types have a year code...
+			if (hcpcsInitialModifierCode.isPresent()) {
+				item.addModifier(TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
+						"" + hcpcsYearCode.get(), hcpcsInitialModifierCode.get()));
+			}
+			if (hcpcsSecondModifierCode.isPresent()) {
+				item.addModifier(TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
+						"" + hcpcsYearCode.get(), hcpcsSecondModifierCode.get()));
+			}
+		}
+		else { // while others do not...
+			if (hcpcsInitialModifierCode.isPresent()) {
+				item.addModifier(TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
+						hcpcsInitialModifierCode.get()));
+			}
+			if (hcpcsSecondModifierCode.isPresent()) {
+				item.addModifier(TransformerUtils.createCodeableConcept(TransformerConstants.CODING_HCPCS,
+						hcpcsSecondModifierCode.get()));
+			}
+		}
+	}
 }
 

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CarrierClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CarrierClaimTransformerTest.java
@@ -131,9 +131,8 @@ public final class CarrierClaimTransformerTest {
 		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS,
 				"" + claim.getHcpcsYearCode().get(), claimLine1.getHcpcsCode().get(), eobItem0.getService());
 		Assert.assertEquals(1, eobItem0.getModifier().size());
-		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS,
-				"" + claim.getHcpcsYearCode().get(), claimLine1.getHcpcsInitialModifierCode().get(),
-				eobItem0.getModifier().get(0));
+		TransformerTestUtils.assertHcpcsModiferCodes(eobItem0, claimLine1.getHcpcsInitialModifierCode(),
+				claimLine1.getHcpcsSecondModifierCode(), claim.getHcpcsYearCode(), 0/*index*/);
 
 		TransformerTestUtils.assertExtensionCodingEquals(eobItem0, TransformerConstants.EXTENSION_CODING_MTUS,
 				TransformerConstants.EXTENSION_CODING_MTUS, String.valueOf(claimLine1.getMtusCode().get()));

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformerTest.java
@@ -127,12 +127,9 @@ public final class DMEClaimTransformerTest {
 		TransformerTestUtils.assertExtensionCodingEquals(eobItem0.getLocation(),
 				TransformerConstants.EXTENSION_CODING_CCW_PROVIDER_STATE,
 				TransformerConstants.EXTENSION_CODING_CCW_PROVIDER_STATE, claimLine1.getProviderStateCode());
-
-		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS,
-				claimLine1.getHcpcsInitialModifierCode().get(),
-				eobItem0.getModifier().get(0));
-		Assert.assertFalse(claimLine1.getHcpcsSecondModifierCode().isPresent());
-
+		
+		TransformerTestUtils.assertHcpcsModiferCodes(eobItem0, claimLine1.getHcpcsInitialModifierCode(),
+				claimLine1.getHcpcsSecondModifierCode(), claim.getHcpcsYearCode(), 0/*index*/);
 		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS, "" + claim.getHcpcsYearCode().get(),
 				claimLine1.getHcpcsCode().get(), eobItem0.getService());
 

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HHAClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HHAClaimTransformerTest.java
@@ -112,11 +112,8 @@ public final class HHAClaimTransformerTest {
 
 		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS, claimLine1.getHcpcsCode().get(),
 				eobItem0.getService());
-		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS,
-				claimLine1.getHcpcsInitialModifierCode().get(),
-				eobItem0.getModifier().get(0));
-		Assert.assertFalse(claimLine1.getHcpcsSecondModifierCode().isPresent());
-			
+		TransformerTestUtils.assertHcpcsModiferCodes(eobItem0, claimLine1.getHcpcsInitialModifierCode(),
+				claimLine1.getHcpcsSecondModifierCode(), Optional.empty(), 0/*index*/);
 		TransformerTestUtils.assertAdjudicationEquals(TransformerConstants.CODED_ADJUDICATION_RATE_AMOUNT,
 				claimLine1.getRateAmount(),
 				eobItem0.getAdjudication());

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HospiceClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/HospiceClaimTransformerTest.java
@@ -116,9 +116,8 @@ public final class HospiceClaimTransformerTest {
 
 		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS, claimLine1.getHcpcsCode().get(),
 				eobItem0.getService());
-		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS,
-				claimLine1.getHcpcsInitialModifierCode().get(), eobItem0.getModifier().get(0));
-		Assert.assertFalse(claimLine1.getHcpcsSecondModifierCode().isPresent());
+		TransformerTestUtils.assertHcpcsModiferCodes(eobItem0, claimLine1.getHcpcsInitialModifierCode(),
+				claimLine1.getHcpcsSecondModifierCode(), Optional.empty(), 0/*index*/);
 
 		TransformerTestUtils.assertAdjudicationEquals(TransformerConstants.CODED_ADJUDICATION_PROVIDER_PAYMENT_AMOUNT,
 				claimLine1.getProviderPaymentAmount(), eobItem0.getAdjudication());

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/OutpatientClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/OutpatientClaimTransformerTest.java
@@ -150,9 +150,8 @@ public final class OutpatientClaimTransformerTest {
 
 		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS, claimLine1.getHcpcsCode().get(),
 				eobItem0.getModifier().get(0));
-		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS,
-				claimLine1.getHcpcsInitialModifierCode().get(), eobItem0.getModifier().get(1));
-		Assert.assertFalse(claimLine1.getHcpcsSecondModifierCode().isPresent());
+		TransformerTestUtils.assertHcpcsModiferCodes(eobItem0, claimLine1.getHcpcsInitialModifierCode(),
+				claimLine1.getHcpcsSecondModifierCode(), Optional.empty(), 1/*index*/);
 
 		TransformerTestUtils.assertAdjudicationEquals(TransformerConstants.CODED_ADJUDICATION_BLOOD_DEDUCTIBLE,
 				claimLine1.getBloodDeductibleAmount(), eobItem0.getAdjudication());

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerTestUtils.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerTestUtils.java
@@ -1204,4 +1204,38 @@ final class TransformerTestUtils {
 		assertReferenceIdentifierEquals(TransformerConstants.IDENTIFIER_CMS_PROVIDER_NUMBER,
 				providerNumber, eob.getProvider());
 	}
+	
+	/**
+	 * Tests the hcpcs modifier codes are set as expected in the item component.
+	 * This field is common among these claim types: Carrier, Outpatient, DME,
+	 * Hospice and HHA.
+	 *
+	 * @param item
+	 *            the {@link ItemComponent} this method will test against
+	 * @param hcpcsInitialModifierCode
+	 *            the {@link Optional}&lt;{@link String}&gt; HCPCS_1ST_MDFR_CD:
+	 *            representing the expected hcpcs initial modifier code for the
+	 *            claim
+	 * @param hcpcsSecondModifierCode
+	 *            the {@link Optional}&lt;{@link String}&gt; HCPCS_2ND_MDFR_CD:
+	 *            representing the expected hcpcs second modifier code for the claim
+	 * @param hcpcsYearCode
+	 *            the {@link Optional}&lt;{@link Character}&gt;
+	 *            CARR_CLM_HCPCS_YR_CD: representing the hcpcs year code for the
+	 *            claim
+	 * @param index
+	 *            the {@link int} modifier index in the item containing the expected
+	 *            code
+	 */
+	static void assertHcpcsModiferCodes(ItemComponent item, Optional<String> hcpcsInitialModifierCode,
+			Optional<String> hcpcsSecondModifierCode, Optional<Character> hcpcsYearCode, int index) {
+		if (hcpcsYearCode.isPresent()) { // some claim types have a year code...
+			assertHasCoding(TransformerConstants.CODING_HCPCS, "" + hcpcsYearCode.get(), hcpcsInitialModifierCode.get(),
+					item.getModifier().get(index));
+		} else { // while others do not...
+			assertHasCoding(TransformerConstants.CODING_HCPCS, hcpcsInitialModifierCode.get(),
+					item.getModifier().get(index));
+		}
+		Assert.assertFalse(hcpcsSecondModifierCode.isPresent());
+	}
 }


### PR DESCRIPTION
…cs modifier codes for the following claim types: Carrier, DME, HHA, Hospice and Outpatient.  Also updated the tests to use a common method in TransformerTestUtils.