### PR TITLE
CBBF-120: Carrier claim types set the organization at the claim line …

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
@@ -1430,11 +1430,12 @@ public final class TransformerUtils {
 					organizationNpi.get()));
 			eob.setFacility(TransformerUtils.createIdentifierReference(TransformerConstants.CODING_NPI_US,
 					organizationNpi.get()));
-			TransformerUtils.addExtensionCoding(eob.getFacility(),
-					TransformerConstants.EXTENSION_CODING_CCW_FACILITY_TYPE,
-					TransformerConstants.EXTENSION_CODING_CCW_FACILITY_TYPE, String.valueOf(claimFacilityTypeCode));
 		}
 
+		TransformerUtils.addExtensionCoding(eob.getFacility(),
+				TransformerConstants.EXTENSION_CODING_CCW_FACILITY_TYPE,
+				TransformerConstants.EXTENSION_CODING_CCW_FACILITY_TYPE, String.valueOf(claimFacilityTypeCode));
+		
 		TransformerUtils.addInformation(eob, TransformerUtils.createCodeableConcept(
 					TransformerConstants.CODING_CCW_CLAIM_FREQUENCY, String.valueOf(claimFrequencyCode)));
 


### PR DESCRIPTION
…level so this mapping issue was already completed by Dave in CBBF-115-118-121.  The set facility type code was moved outside of the ispresent test of organization npi as that dependency does not apply for that type code.