### PR TITLE
Cbbf 126 provider number is not mapped for the dme claim type at the eob level

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformer.java
@@ -7,6 +7,8 @@ import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit.BenefitBalanceComponent;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit.BenefitComponent;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit.ItemComponent;
+import org.hl7.fhir.dstu3.model.Extension;
+import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Money;
 import org.hl7.fhir.dstu3.model.codesystems.BenefitCategory;
 import org.hl7.fhir.dstu3.model.codesystems.ClaimCareteamrole;
@@ -51,15 +53,7 @@ final class DMEClaimTransformer {
 		// map eob type codes into FHIR
 		TransformerUtils.mapEobType(eob, ClaimType.DME, Optional.of(claimGroup.getNearLineRecordIdCode()), 
 				Optional.of(claimGroup.getClaimTypeCode()));
-		
-		/*
-		 * TODO: DME does not have a provider number at the EOB level to map to but has
-		 * provider billing numbers at the claim line level. Need to do some research on
-		 * how this should be mapped, if it even can be, like the other claim types:
-		 * 
-		 * TransformerUtils.setProviderNumber(eob, claimGroup.getProviderNumber());
-		 */
-		
+
 		if (claimGroup.getClinicalTrialNumber().isPresent()) {
 			/*
 			 * FIXME this should be mapped as an extension valueIdentifier
@@ -114,13 +108,24 @@ final class DMEClaimTransformer {
 			item.setSequence(claimLine.getLineNumber().intValue());
 
 			/*
-			 * Per Michelle at GDIT, and also Tony Dean at OEDA, the performing
-			 * provider _should_ always be present. However, we've found some
-			 * examples in production where it's not for some claim lines. (This
-			 * is annoying, as it's present on other lines in the same claim,
-			 * and the data indicates that the same NPI probably applies to the
-			 * lines where it's not specified. Still, it's not safe to guess at
-			 * this, so we'll leave it blank.)
+			 * add an extension for the provider billing number as there is not a good place
+			 * to map this in the existing FHIR specification
+			 */
+			if (claimLine.getProviderBillingNumber().isPresent()) {
+				Extension providerNumberExtension = item.addExtension();
+				providerNumberExtension.setUrl(TransformerConstants.EXTENSION_IDENTIFIER_DME_PROVIDER_BILLING_NUMBER);
+				providerNumberExtension.setValue(new Identifier()
+						.setSystem(TransformerConstants.EXTENSION_IDENTIFIER_DME_PROVIDER_BILLING_NUMBER)
+						.setValue(claimLine.getProviderBillingNumber().get()));
+			}
+
+			/*
+			 * Per Michelle at GDIT, and also Tony Dean at OEDA, the performing provider
+			 * _should_ always be present. However, we've found some examples in production
+			 * where it's not for some claim lines. (This is annoying, as it's present on
+			 * other lines in the same claim, and the data indicates that the same NPI
+			 * probably applies to the lines where it's not specified. Still, it's not safe
+			 * to guess at this, so we'll leave it blank.)
 			 */
 			if (claimLine.getProviderNPI().isPresent()) {
 				ExplanationOfBenefit.CareTeamComponent performingCareTeamMember = TransformerUtils

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
@@ -465,6 +465,9 @@ final class TransformerConstants {
 
 	static final String EXTENSION_IDENTIFIER_CLINICAL_TRIAL_NUMBER = "https://www.ccwdata.org/cs/groups/public/documents/datadictionary/ccltrnum.txt";
 
+	// FIXME: needs to link to an explanation of what this extension coding is
+	static final String EXTENSION_IDENTIFIER_DME_PROVIDER_BILLING_NUMBER = "https://bluebutton.cms.gov/resources/suplrnum";
+
 	static final String EXTENSION_IDENTIFIER_PDE_PLAN_BENEFIT_PACKAGE_ID = "https://www.ccwdata.org/cs/groups/public/documents/datadictionary/plan_pbp_rec_num.txt";
 
 	static final String EXTENSION_IDENTIFIER_PDE_PLAN_CONTRACT_ID = "https://www.ccwdata.org/cs/groups/public/documents/datadictionary/plan_cntrct_rec_id.txt";

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformerTest.java
@@ -62,14 +62,6 @@ public final class DMEClaimTransformerTest {
 						Optional.of(claim.getDateFrom()), Optional.of(claim.getDateThrough()),
 				Optional.of(claim.getPaymentAmount()), claim.getFinalAction());
 
-		/*
-		 * TODO: DME does not have a provider number at the EOB level to map to but has
-		 * provider billing numbers at the claim line level. Need to do some research on
-		 * how this should be mapped, if it even can be, like the other claim types:
-		 * 
-		 * TransformerTestUtils.assertProviderNumber(eob, claimGroup.getProviderNumber());
-		 */
-
 		// Test to ensure common group fields between Carrier and DME match
 		TransformerTestUtils.assertEobCommonGroupCarrierDMEEquals(eob, claim.getBeneficiaryId(),
 				claim.getCarrierNumber(),
@@ -87,6 +79,10 @@ public final class DMEClaimTransformerTest {
 		ItemComponent eobItem0 = eob.getItem().get(0);
 		DMEClaimLine claimLine1 = claim.getLines().get(0);
 		Assert.assertEquals(claimLine1.getLineNumber(), new BigDecimal(eobItem0.getSequence()));
+
+		TransformerTestUtils.assertExtensionIdentifierEqualsString(
+				eobItem0.getExtensionsByUrl(TransformerConstants.EXTENSION_IDENTIFIER_DME_PROVIDER_BILLING_NUMBER),
+				claimLine1.getProviderBillingNumber().get());
 
 		TransformerTestUtils.assertCareTeamEquals(claimLine1.getProviderNPI().get(),
 				ClaimCareteamrole.PRIMARY.toCode(), eob);

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformerTest.java
@@ -136,10 +136,6 @@ public final class DMEClaimTransformerTest {
 		TransformerTestUtils.assertExtensionCodingEquals(eobItem0, TransformerConstants.CODING_NDC,
 				TransformerConstants.CODING_NDC, claimLine1.getNationalDrugCode().get());
 		
-		TransformerTestUtils.assertExtensionCodingEquals(eobItem0,
-				TransformerConstants.EXTENSION_CODING_CCW_PROVIDER_NUMBER,
-				TransformerConstants.EXTENSION_CODING_CCW_PROVIDER_NUMBER, claimLine1.getProviderBillingNumber().get());
-		
 		// verify {@link
 		// TransformerUtils#mapEobType(CodeableConcept,ClaimType,Optional,Optional)}
 		// method worked as expected for this claim type

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerTestUtils.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerTestUtils.java
@@ -347,6 +347,22 @@ final class TransformerTestUtils {
 	}
 
 	/**
+	 * Tests that the specified extension list contains a single Identifier with the
+	 * expected string value
+	 *
+	 * @param extension
+	 *            a {@link List}&lt;{@link Extension}&gt; containing an Identifier
+	 * @param expected
+	 *            a {@link String} containing the expected value of the Identifier
+	 */
+	static void assertExtensionIdentifierEqualsString(List<Extension> extension, String expected) {
+		Assert.assertEquals(1, extension.size());
+		Assert.assertTrue(extension.get(0).getValue() instanceof Identifier);
+		Identifier identifier = (Identifier) extension.get(0).getValue();
+		Assert.assertEquals(expected, identifier.getValue());
+	}
+
+	/**
 	 * @param expectedSystem
 	 *            the expected {@link Coding#getSystem()} of the
 	 *            {@link SupportingInformationComponent#getCategory()} to find

--- a/dev/api-changelog.md
+++ b/dev/api-changelog.md
@@ -1,5 +1,9 @@
 # API Changelog
 
+## CBBF-126 (Sprint 44, 2018-02)
+* Added an extension coding for DME provider billing number at the item level
+	1. A temporary URL has been added https://bluebutton.cms.gov/resources/suplrnum
+
 ## CBBD-385 (Sprint 43, 2018-01)
 
 * Standardized the [ExplanationOfBenefit.type](http://hl7.org/fhir/explanationofbenefit-definitions.html#ExplanationOfBenefit.type) field across all 8 claim types. This field's `CodeableConcept` will now have some of these possible `Coding`s:


### PR DESCRIPTION
I merged the master in.  One change of note from master is the providerBillingNumber was mapped as a CodeableConcept but is now mapped as an extension identifier string at the item level in the eob.