### PR TITLE
Cbbf 127 modify fhir extension design

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
@@ -201,13 +201,7 @@ public final class TransformerUtils {
 			String codingCode) {
 		IBaseExtension<?, ?> extension = fhirElement.addExtension();
 		extension.setUrl(extensionUrl);
-		extension.setValue(new Coding());
-	
-		CodeableConcept codeableConcept = new CodeableConcept();
-		extension.setValue(codeableConcept);
-	
-		Coding coding = codeableConcept.addCoding();
-		coding.setSystem(codingSystem).setCode(codingCode);
+		extension.setValue(new Coding().setSystem(codingSystem).setCode(codingCode));
 	}
 
 	/**

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CCWProcedureTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CCWProcedureTest.java
@@ -47,7 +47,7 @@ public class CCWProcedureTest {
 		Assert.assertEquals(procDate.get(), diagnosis.get().getProcedureDate());
 		Assert.assertEquals(system, diagnosis.get().getFhirSystem());
 
-		TransformerTestUtils.assertHasCoding(system, code.get(), diagnosis.get().toCodeableConcept());
+		TransformerTestUtils.assertHasCoding(system, code.get(), diagnosis.get().toCodeableConcept().getCoding());
 
 		CodeableConcept codeableConcept = new CodeableConcept();
 		Coding coding = codeableConcept.addCoding();

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CarrierClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CarrierClaimTransformerTest.java
@@ -110,7 +110,7 @@ public final class CarrierClaimTransformerTest {
 		CareTeamComponent performingCareTeamEntry = TransformerTestUtils.findCareTeamEntryForProviderIdentifier(
 				claimLine1.getPerformingPhysicianNpi().get(), eob.getCareTeam());
 		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_CCW_PROVIDER_SPECIALTY,
-				claimLine1.getProviderSpecialityCode().get(), performingCareTeamEntry.getQualification());
+				claimLine1.getProviderSpecialityCode().get(), performingCareTeamEntry.getQualification().getCoding());
 		TransformerTestUtils.assertExtensionCodingEquals(performingCareTeamEntry,
 				TransformerConstants.EXTENSION_CODING_CCW_PROVIDER_TYPE,
 				TransformerConstants.EXTENSION_CODING_CCW_PROVIDER_TYPE, "" + claimLine1.getProviderTypeCode());
@@ -134,7 +134,7 @@ public final class CarrierClaimTransformerTest {
 				TransformerConstants.EXTENSION_CODING_CCW_PRICING_LOCALITY, "15");
 
 		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS,
-				"" + claim.getHcpcsYearCode().get(), claimLine1.getHcpcsCode().get(), eobItem0.getService());
+				"" + claim.getHcpcsYearCode().get(), claimLine1.getHcpcsCode().get(), eobItem0.getService().getCoding());
 		Assert.assertEquals(1, eobItem0.getModifier().size());
 		TransformerTestUtils.assertHcpcsCodes(eobItem0, claimLine1.getHcpcsCode(),
 				claimLine1.getHcpcsInitialModifierCode(), claimLine1.getHcpcsSecondModifierCode(), claim.getHcpcsYearCode(),

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DMEClaimTransformerTest.java
@@ -89,7 +89,7 @@ public final class DMEClaimTransformerTest {
 		CareTeamComponent performingCareTeamEntry = TransformerTestUtils.findCareTeamEntryForProviderIdentifier(
 				claimLine1.getProviderNPI().get(), eob.getCareTeam());
 		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_CCW_PROVIDER_SPECIALTY,
-				claimLine1.getProviderSpecialityCode().get(), performingCareTeamEntry.getQualification());
+				claimLine1.getProviderSpecialityCode().get(), performingCareTeamEntry.getQualification().getCoding());
 		TransformerTestUtils.assertExtensionCodingEquals(performingCareTeamEntry,
 				TransformerConstants.EXTENSION_CODING_CCW_PROVIDER_PARTICIPATING,
 				TransformerConstants.EXTENSION_CODING_CCW_PROVIDER_PARTICIPATING,
@@ -108,7 +108,7 @@ public final class DMEClaimTransformerTest {
 				claimLine1.getHcpcsInitialModifierCode(), claimLine1.getHcpcsSecondModifierCode(), claim.getHcpcsYearCode(),
 				0/* index */);
 		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_HCPCS, "" + claim.getHcpcsYearCode().get(),
-				claimLine1.getHcpcsCode().get(), eobItem0.getService());
+				claimLine1.getHcpcsCode().get(), eobItem0.getService().getCoding());
 
 		TransformerTestUtils.assertAdjudicationEquals(
 				TransformerConstants.CODED_ADJUDICATION_LINE_PRIMARY_PAYER_ALLOWED_CHARGE,

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DiagnosisTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/DiagnosisTest.java
@@ -52,7 +52,7 @@ public class DiagnosisTest {
 		Assert.assertEquals(prsntOnAdmsn, diagnosis.get().getPresentOnAdmission());
 		Assert.assertEquals(system, diagnosis.get().getFhirSystem());
 
-		TransformerTestUtils.assertHasCoding(system, code.get(), diagnosis.get().toCodeableConcept());
+		TransformerTestUtils.assertHasCoding(system, code.get(), diagnosis.get().toCodeableConcept().getCoding());
 
 		CodeableConcept codeableConcept = new CodeableConcept();
 		Coding coding = codeableConcept.addCoding();

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/InpatientClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/InpatientClaimTransformerTest.java
@@ -123,7 +123,7 @@ public final class InpatientClaimTransformerTest {
 				claim.getProcedure1Date());
 		TransformerTestUtils.assertHasCoding(ccwProcedure.getFhirSystem().toString(),
 				claim.getProcedure1Code().get(),
-				eob.getProcedure().get(0).getProcedureCodeableConcept());
+				eob.getProcedure().get(0).getProcedureCodeableConcept().getCoding());
 		Assert.assertEquals(
 				Date.from(claim.getProcedure1Date().get().atStartOfDay(ZoneId.systemDefault()).toInstant()),
 				eob.getProcedure().get(0).getDate());

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/OutpatientClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/OutpatientClaimTransformerTest.java
@@ -99,7 +99,7 @@ public final class OutpatientClaimTransformerTest {
 		CCWProcedure ccwProcedure = new CCWProcedure(claim.getProcedure1Code(), claim.getProcedure1CodeVersion(),
 				claim.getProcedure1Date());
 		TransformerTestUtils.assertHasCoding(ccwProcedure.getFhirSystem().toString(), claim.getProcedure1Code().get(),
-				eob.getProcedure().get(0).getProcedureCodeableConcept());
+				eob.getProcedure().get(0).getProcedureCodeableConcept().getCoding());
 		Assert.assertEquals(Date.from(claim.getProcedure1Date().get().atStartOfDay(ZoneId.systemDefault()).toInstant()),
 				eob.getProcedure().get(0).getDate());
 

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PartDEventTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PartDEventTransformerTest.java
@@ -71,9 +71,9 @@ public final class PartDEventTransformerTest {
 		ItemComponent rxItem = eob.getItem().stream().filter(i -> i.getSequence() == 1).findAny().get();
 
 		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_NDC, claim.getNationalDrugCode(),
-				rxItem.getService());
+				rxItem.getService().getCoding());
 
-		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_FHIR_ACT, "RXDINV", rxItem.getDetail().get(0).getType());
+		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_FHIR_ACT, "RXDINV", rxItem.getDetail().get(0).getType().getCoding());
 
 		Assert.assertEquals(Date.valueOf(claim.getPrescriptionFillDate()), rxItem.getServicedDateType().getValue());
 

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/SNFClaimTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/SNFClaimTransformerTest.java
@@ -114,7 +114,7 @@ public final class SNFClaimTransformerTest {
 		CCWProcedure ccwProcedure = new CCWProcedure(claim.getProcedure1Code(), claim.getProcedure1CodeVersion(),
 				claim.getProcedure1Date());
 		TransformerTestUtils.assertHasCoding(ccwProcedure.getFhirSystem().toString(), claim.getProcedure1Code().get(),
-				eob.getProcedure().get(0).getProcedureCodeableConcept());
+				eob.getProcedure().get(0).getProcedureCodeableConcept().getCoding());
 		Assert.assertEquals(Date.from(claim.getProcedure1Date().get().atStartOfDay(ZoneId.systemDefault()).toInstant()),
 				eob.getProcedure().get(0).getDate());
 
@@ -133,7 +133,7 @@ public final class SNFClaimTransformerTest {
 				eobItem0.getLocationAddress().getState());
 
 		TransformerTestUtils.assertHasCoding(TransformerConstants.CODING_CMS_REVENUE_CENTER,
-				claimLine1.getRevenueCenter(), eobItem0.getRevenue());
+				claimLine1.getRevenueCenter(), eobItem0.getRevenue().getCoding());
 		TransformerTestUtils.assertHcpcsCodes(eobItem0, claimLine1.getHcpcsCode(), Optional.empty(), Optional.empty(),
 				Optional.empty(), 0/* index */);
 


### PR DESCRIPTION
This flattens the json output from a query.  Specifically uses Option 4 as described here [Extension Design](https://confluence.cms.gov/pages/viewpage.action?spaceKey=BB&title=Extension+Design)