### PR TITLE
Temporarily disable slow DB queries.

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProvider.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProvider.java
@@ -185,8 +185,9 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 		else
 			dateRange = Optional.of(dateRangeParam);
 
-		eobs.addAll(findCarrierClaimsByPatient(patient, dateRange).stream().map(ClaimType.CARRIER.getTransformer())
-				.collect(Collectors.toList()));
+		// eobs.addAll(findCarrierClaimsByPatient(patient,
+		// dateRange).stream().map(ClaimType.CARRIER.getTransformer())
+		// .collect(Collectors.toList()));
 		eobs.addAll(findDMEClaimsByPatient(patient, dateRange).stream().map(ClaimType.DME.getTransformer())
 				.collect(Collectors.toList()));
 		eobs.addAll(findHHAClaimsByPatient(patient, dateRange).stream().map(ClaimType.HHA.getTransformer())
@@ -195,13 +196,12 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 				.collect(Collectors.toList()));
 		eobs.addAll(findInpatientClaimsByPatient(patient, dateRange).stream().map(ClaimType.INPATIENT.getTransformer())
 				.collect(Collectors.toList()));
-		eobs.addAll(findOutpatientClaimsByPatient(patient, dateRange).stream()
-				.map(ClaimType.OUTPATIENT.getTransformer()).collect(Collectors.toList()));
+		// eobs.addAll(findOutpatientClaimsByPatient(patient, dateRange).stream()
+		// .map(ClaimType.OUTPATIENT.getTransformer()).collect(Collectors.toList()));
 		eobs.addAll(findPartDEventsByPatient(patient, dateRange).stream().map(ClaimType.PDE.getTransformer())
 				.collect(Collectors.toList()));
 		eobs.addAll(findSNFClaimsByPatient(patient, dateRange).stream().map(ClaimType.SNF.getTransformer())
 				.collect(Collectors.toList()));
-		 
 
 		return eobs;
 	}

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
@@ -363,13 +363,15 @@ public final class ExplanationOfBenefitResourceProviderIT {
 
 		CarrierClaim carrierClaim = loadedRecords.stream().filter(r -> r instanceof CarrierClaim)
 				.map(r -> (CarrierClaim) r).findFirst().get();
-		ExplanationOfBenefit carrierClaimFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
-				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-				.map(e -> (ExplanationOfBenefit) e.getResource())
-				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.CARRIER.name()))
-				.findFirst().get();
-		CarrierClaimTransformerTest.assertMatches(carrierClaim, carrierClaimFromSearchResult);
+		// ExplanationOfBenefit carrierClaimFromSearchResult = (ExplanationOfBenefit)
+		// searchResults.getEntry().stream()
+		// .filter(e -> e.getResource() instanceof ExplanationOfBenefit)
+		// .map(e -> (ExplanationOfBenefit) e.getResource())
+		// .filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
+		// TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.CARRIER.name()))
+		// .findFirst().get();
+		// CarrierClaimTransformerTest.assertMatches(carrierClaim,
+		// carrierClaimFromSearchResult);
 
 		DMEClaim dmeClaim = loadedRecords.stream().filter(r -> r instanceof DMEClaim).map(r -> (DMEClaim) r).findFirst()
 				.get();
@@ -413,13 +415,16 @@ public final class ExplanationOfBenefitResourceProviderIT {
 
 		OutpatientClaim outpatientClaim = loadedRecords.stream().filter(r -> r instanceof OutpatientClaim)
 				.map(r -> (OutpatientClaim) r).findFirst().get();
-		ExplanationOfBenefit outpatientClaimFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
-				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-				.map(e -> (ExplanationOfBenefit) e.getResource())
-				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.OUTPATIENT.name()))
-				.findFirst().get();
-		OutpatientClaimTransformerTest.assertMatches(outpatientClaim, outpatientClaimFromSearchResult);
+		// ExplanationOfBenefit outpatientClaimFromSearchResult = (ExplanationOfBenefit)
+		// searchResults.getEntry().stream()
+		// .filter(e -> e.getResource() instanceof ExplanationOfBenefit)
+		// .map(e -> (ExplanationOfBenefit) e.getResource())
+		// .filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
+		// TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE,
+		// ClaimType.OUTPATIENT.name()))
+		// .findFirst().get();
+		// OutpatientClaimTransformerTest.assertMatches(outpatientClaim,
+		// outpatientClaimFromSearchResult);
 
 		PartDEvent partDEvent = loadedRecords.stream().filter(r -> r instanceof PartDEvent).map(r -> (PartDEvent) r)
 				.findFirst().get();


### PR DESCRIPTION
Bad and ugly: carrier and outpatient claims will not be returned at all. But still better than queries that take 3h+ to complete.

Please note that this is bad enough that I'm treating it as a quasi-incident, even though we're not live yet. Accordingly, this patch has already been deployed to try and "stop the bleeding." It's even more important for us to get these types of emergency changes reviewed ASAP, though.

https://issues.hhsdevcloud.us/browse/CBBI-357