### PR TITLE
cbbf-171 enhance code to allow for optional procedure date

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CCWProcedure.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CCWProcedure.java
@@ -31,11 +31,7 @@ final class CCWProcedure extends IcdCode {
 		Objects.requireNonNull(icdVersionCode);
 		Objects.requireNonNull(procedureDate);
 
-		if (procedureDate.isPresent()) {
-			this.procedureDate = procedureDate;
-		} else {
-			this.procedureDate = Optional.empty();
-		}
+		this.procedureDate = procedureDate;
 	}
 
 	/**

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CCWProcedure.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CCWProcedure.java
@@ -9,7 +9,7 @@ import java.util.Optional;
  */
 final class CCWProcedure extends IcdCode {
 
-	private LocalDate procedureDate;
+	private Optional<LocalDate> procedureDate;
 
 	/**
 	 * Constructs a new {@link CCWProcedure}.
@@ -31,14 +31,18 @@ final class CCWProcedure extends IcdCode {
 		Objects.requireNonNull(icdVersionCode);
 		Objects.requireNonNull(procedureDate);
 
-		this.procedureDate = procedureDate.get();
-
+		if (procedureDate.isPresent()) {
+			this.procedureDate = procedureDate;
+		} else {
+			this.procedureDate = Optional.empty();
+		}
 	}
 
 	/**
-	 * @return the ICD procedure date
+	 * @return the ICD procedure date or {@link Optional#empty()} if no date is
+	 *         present
 	 */
-	public LocalDate getProcedureDate() {
+	public Optional<LocalDate> getProcedureDate() {
 		return procedureDate;
 	}
 

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
@@ -518,7 +518,9 @@ public final class TransformerUtils {
 
 		ProcedureComponent procedureComponent = new ProcedureComponent().setSequence(eob.getProcedure().size() + 1);
 		procedureComponent.setProcedure(createCodeableConcept(procedure.getFhirSystem(), procedure.getCode()));
-		procedureComponent.setDate(convertToDate(procedure.getProcedureDate()));
+		if (procedure.getProcedureDate().isPresent()) {
+			procedureComponent.setDate(convertToDate(procedure.getProcedureDate().get()));
+		}
 
 		eob.getProcedure().add(procedureComponent);
 		return procedureComponent.getSequenceElement().getValue();

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CCWProcedureTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CCWProcedureTest.java
@@ -44,7 +44,7 @@ public class CCWProcedureTest {
 
 		Optional<CCWProcedure> diagnosis = CCWProcedure.from(code, Optional.of(version), procDate);
 
-		Assert.assertEquals(procDate.get(), diagnosis.get().getProcedureDate());
+		Assert.assertEquals(procDate.get(), diagnosis.get().getProcedureDate().get());
 		Assert.assertEquals(system, diagnosis.get().getFhirSystem());
 
 		TransformerTestUtils.assertHasCoding(system, code.get(), diagnosis.get().toCodeableConcept().getCoding());

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CCWProcedureTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/CCWProcedureTest.java
@@ -35,6 +35,8 @@ public class CCWProcedureTest {
 		Character versionIcdUnknown = 'U';
 		String systemIcdUnknown = String.format("http://hl7.org/fhir/sid/unknown-icd-version/%s", versionIcdUnknown);
 		assertMatches(versionIcdUnknown, systemIcdUnknown);
+
+		assertDateNotPresent(versionIcdUnknown, systemIcdUnknown);
 	}
 
 	static void assertMatches(Character version, String system) {
@@ -45,6 +47,30 @@ public class CCWProcedureTest {
 		Optional<CCWProcedure> diagnosis = CCWProcedure.from(code, Optional.of(version), procDate);
 
 		Assert.assertEquals(procDate.get(), diagnosis.get().getProcedureDate().get());
+		Assert.assertEquals(system, diagnosis.get().getFhirSystem());
+
+		TransformerTestUtils.assertHasCoding(system, code.get(), diagnosis.get().toCodeableConcept().getCoding());
+
+		CodeableConcept codeableConcept = new CodeableConcept();
+		Coding coding = codeableConcept.addCoding();
+		coding.setSystem(system).setCode(code.get());
+
+		Assert.assertTrue(diagnosis.get().isContainedIn(codeableConcept));
+	}
+
+	/**
+	 * Verifies that a procedure date isn't present even though there is a procedure
+	 * code present
+	 */
+	static void assertDateNotPresent(Character version, String system) {
+
+		Optional<String> code = Optional.of("code");
+		Optional<LocalDate> procDate = Optional.empty();
+
+		Optional<CCWProcedure> diagnosis = CCWProcedure.from(code, Optional.of(version), procDate);
+
+		Assert.assertEquals(Optional.empty(), diagnosis.get().getProcedureDate());
+
 		Assert.assertEquals(system, diagnosis.get().getFhirSystem());
 
 		TransformerTestUtils.assertHasCoding(system, code.get(), diagnosis.get().toCodeableConcept().getCoding());


### PR DESCRIPTION
Enhanced code to allow for optional procedure date when procedure code is present.  Procedure date was assumed to be present when procedure code was also present before; now the date isn't required. 