### PR TITLE
CBBI-357: Slow DB Queries Bandaid #2

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/SpringConfiguration.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/SpringConfiguration.java
@@ -260,6 +260,14 @@ public class SpringConfiguration {
 
 		poolingDataSource.setMaximumPoolSize(connectionsMax);
 
+		/*
+		 * FIXME Temporary workaround for CBBI-357: send Postgres' query planner a
+		 * strongly worded letter instructing it to avoid sequential scans whenever
+		 * possible.
+		 */
+		if (poolingDataSource.getJdbcUrl().contains("postgre"))
+			poolingDataSource.setConnectionInitSql("set enable_seqscan = false;");
+
 		poolingDataSource.setRegisterMbeans(true);
 		poolingDataSource.setMetricRegistry(metricRegistry);
 	}

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProvider.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProvider.java
@@ -185,9 +185,8 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 		else
 			dateRange = Optional.of(dateRangeParam);
 
-		// eobs.addAll(findCarrierClaimsByPatient(patient,
-		// dateRange).stream().map(ClaimType.CARRIER.getTransformer())
-		// .collect(Collectors.toList()));
+		eobs.addAll(findCarrierClaimsByPatient(patient, dateRange).stream().map(ClaimType.CARRIER.getTransformer())
+				.collect(Collectors.toList()));
 		eobs.addAll(findDMEClaimsByPatient(patient, dateRange).stream().map(ClaimType.DME.getTransformer())
 				.collect(Collectors.toList()));
 		eobs.addAll(findHHAClaimsByPatient(patient, dateRange).stream().map(ClaimType.HHA.getTransformer())
@@ -196,12 +195,13 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 				.collect(Collectors.toList()));
 		eobs.addAll(findInpatientClaimsByPatient(patient, dateRange).stream().map(ClaimType.INPATIENT.getTransformer())
 				.collect(Collectors.toList()));
-		// eobs.addAll(findOutpatientClaimsByPatient(patient, dateRange).stream()
-		// .map(ClaimType.OUTPATIENT.getTransformer()).collect(Collectors.toList()));
+		eobs.addAll(findOutpatientClaimsByPatient(patient, dateRange).stream()
+				.map(ClaimType.OUTPATIENT.getTransformer()).collect(Collectors.toList()));
 		eobs.addAll(findPartDEventsByPatient(patient, dateRange).stream().map(ClaimType.PDE.getTransformer())
 				.collect(Collectors.toList()));
 		eobs.addAll(findSNFClaimsByPatient(patient, dateRange).stream().map(ClaimType.SNF.getTransformer())
 				.collect(Collectors.toList()));
+		 
 
 		return eobs;
 	}

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
@@ -363,15 +363,13 @@ public final class ExplanationOfBenefitResourceProviderIT {
 
 		CarrierClaim carrierClaim = loadedRecords.stream().filter(r -> r instanceof CarrierClaim)
 				.map(r -> (CarrierClaim) r).findFirst().get();
-		// ExplanationOfBenefit carrierClaimFromSearchResult = (ExplanationOfBenefit)
-		// searchResults.getEntry().stream()
-		// .filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-		// .map(e -> (ExplanationOfBenefit) e.getResource())
-		// .filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-		// TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.CARRIER.name()))
-		// .findFirst().get();
-		// CarrierClaimTransformerTest.assertMatches(carrierClaim,
-		// carrierClaimFromSearchResult);
+		ExplanationOfBenefit carrierClaimFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
+				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
+				.map(e -> (ExplanationOfBenefit) e.getResource())
+				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
+						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.CARRIER.name()))
+				.findFirst().get();
+		CarrierClaimTransformerTest.assertMatches(carrierClaim, carrierClaimFromSearchResult);
 
 		DMEClaim dmeClaim = loadedRecords.stream().filter(r -> r instanceof DMEClaim).map(r -> (DMEClaim) r).findFirst()
 				.get();
@@ -415,16 +413,13 @@ public final class ExplanationOfBenefitResourceProviderIT {
 
 		OutpatientClaim outpatientClaim = loadedRecords.stream().filter(r -> r instanceof OutpatientClaim)
 				.map(r -> (OutpatientClaim) r).findFirst().get();
-		// ExplanationOfBenefit outpatientClaimFromSearchResult = (ExplanationOfBenefit)
-		// searchResults.getEntry().stream()
-		// .filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-		// .map(e -> (ExplanationOfBenefit) e.getResource())
-		// .filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-		// TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE,
-		// ClaimType.OUTPATIENT.name()))
-		// .findFirst().get();
-		// OutpatientClaimTransformerTest.assertMatches(outpatientClaim,
-		// outpatientClaimFromSearchResult);
+		ExplanationOfBenefit outpatientClaimFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
+				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
+				.map(e -> (ExplanationOfBenefit) e.getResource())
+				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
+						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.OUTPATIENT.name()))
+				.findFirst().get();
+		OutpatientClaimTransformerTest.assertMatches(outpatientClaim, outpatientClaimFromSearchResult);
 
 		PartDEvent partDEvent = loadedRecords.stream().filter(r -> r instanceof PartDEvent).map(r -> (PartDEvent) r)
 				.findFirst().get();


### PR DESCRIPTION
Switched to a workaround that allows us to leave all subqueries enabled. It's still gross, but definitely an improvement.

(Work continues to try and determine the actual root cause. Right now it's looking like Postgres is sad that it doesn't have more memory to keep the indexes hot.)

https://issues.hhsdevcloud.us/browse/CBBI-357