### PR TITLE
Fixed EOB.diagnosis.type.

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/Diagnosis.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/Diagnosis.java
@@ -7,6 +7,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.ExplanationOfBenefit.DiagnosisComponent;
+import org.hl7.fhir.dstu3.model.codesystems.ExDiagnosistype;
+
+import gov.hhs.cms.bluebutton.data.codebook.data.CcwCodebookVariable;
+
 /**
  * Models a diagnosis code entry in a claim.
  */
@@ -137,6 +143,78 @@ final class Diagnosis extends IcdCode {
 	 * the various diagnoses in a claim.
 	 */
 	static enum DiagnosisLabel {
-		PRINCIPAL, ADMITTING, FIRSTEXTERNAL, EXTERNAL, REASONFORVISIT;
+		/**
+		 * Note: display text matches {@link ExDiagnosistype#PRINCIPAL}.
+		 */
+		PRINCIPAL("principal", "The single medical diagnosis that is most relevant to the patient's chief complaint"
+				+ " or need for treatment."),
+
+		/**
+		 * Note: display text matches {@link ExDiagnosistype#ADMITTING}.
+		 */
+		ADMITTING("admitting", "The diagnosis given as the reason why the patient was admitted to the hospital."),
+
+		/**
+		 * Note: display text (mostly) matches
+		 * {@link CcwCodebookVariable#FST_DGNS_E_CD}.
+		 */
+		FIRSTEXTERNAL("external-first",
+				"The code used to identify the 1st external cause of injury, poisoning, or other adverse effect."),
+
+		/**
+		 * Note: display text (mostly) matches
+		 * {@link CcwCodebookVariable#FST_DGNS_E_CD}.
+		 */
+		EXTERNAL("external",
+				"A code used to identify an external cause of injury, poisoning, or other adverse effect."),
+
+		/**
+		 * Note: display text (mostly) matches
+		 * {@link CcwCodebookVariable#RSN_VISIT_CD1}.
+		 */
+		REASONFORVISIT("reason-for-visit", "A diagnosis code used to identify the patient's reason for the visit.");
+
+		private final String fhirCode;
+		private final String fhirDisplay;
+
+		/**
+		 * Enum constant constructor.
+		 *
+		 * @param fhirCode
+		 *            the value to use for {@link #toCode()}
+		 * @param fhirDisplay
+		 *            the value to use for {@link #getDisplay()}
+		 */
+		private DiagnosisLabel(String fhirCode, String fhirDisplay) {
+			this.fhirCode = fhirCode;
+			this.fhirDisplay = fhirDisplay;
+		}
+
+		/**
+		 * @return the FHIR {@link Coding#getSystem()} to use for the
+		 *         {@link DiagnosisComponent#getType()} that this {@link DiagnosisLabel}
+		 *         should be mapped to
+		 */
+		public String getSystem() {
+			return TransformerConstants.CODING_SYSTEM_BBAPI_DIAGNOSIS_TYPE;
+		}
+
+		/**
+		 * @return the FHIR {@link Coding#getCode()} to use for the
+		 *         {@link DiagnosisComponent#getType()} that this {@link DiagnosisLabel}
+		 *         should be mapped to
+		 */
+		public String toCode() {
+			return fhirCode;
+		}
+
+		/**
+		 * @return the FHIR {@link Coding#getDisplay()} to use for the
+		 *         {@link DiagnosisComponent#getType()} that this {@link DiagnosisLabel}
+		 *         should be mapped to
+		 */
+		public String getDisplay() {
+			return fhirDisplay;
+		}
 	}
 }

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
@@ -4,6 +4,7 @@ import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Coverage;
 import org.hl7.fhir.dstu3.model.Coverage.GroupComponent;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
+import org.hl7.fhir.dstu3.model.ExplanationOfBenefit.DiagnosisComponent;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit.ItemComponent;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit.SupportingInformationComponent;
 import org.hl7.fhir.dstu3.model.Extension;
@@ -140,7 +141,11 @@ final class TransformerConstants {
 	// FIXME this URL has a typo -- first 'c' shouldn't have been there
 	private static final String CODING_CCW_TYPE_SERVICE = "https://www.ccwdata.org/cs/groups/public/documents/datadictionary/typcsrvcb.txt";
 
-	static final String CODING_FHIR_DIAGNOSIS_TYPE = "http://hl7.org/fhir/ex-diagnosistype";
+	/**
+	 * Used as the {@link Coding#getSystem()} for
+	 * {@link DiagnosisComponent#getType()} entries.
+	 */
+	static final String CODING_SYSTEM_BBAPI_DIAGNOSIS_TYPE = BASE_URL_BBAPI_RESOURCES + "/codesystem/diagnosis-type";
 
 	/**
 	 * Used as the {@link Coding#getSystem()} for {@link ItemComponent#getService()}

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
@@ -303,9 +303,11 @@ public final class TransformerUtils {
 		DiagnosisComponent diagnosisComponent = new DiagnosisComponent().setSequence(eob.getDiagnosis().size() + 1);
 		diagnosisComponent.setDiagnosis(diagnosis.toCodeableConcept());
 
-		if (!diagnosis.getLabels().isEmpty()) {
-			diagnosisComponent.addType(createCodeableConcept(TransformerConstants.CODING_FHIR_DIAGNOSIS_TYPE,
-					String.valueOf(diagnosis.getLabels())));
+		for (DiagnosisLabel diagnosisLabel : diagnosis.getLabels()) {
+			CodeableConcept diagnosisTypeConcept = createCodeableConcept(diagnosisLabel.getSystem(),
+					diagnosisLabel.toCode());
+			diagnosisTypeConcept.getCodingFirstRep().setDisplay(diagnosisLabel.getDisplay());
+			diagnosisComponent.addType(diagnosisTypeConcept);
 		}
 		if (diagnosis.getPresentOnAdmission().isPresent()) {
 			diagnosisComponent.addExtension(

--- a/dev/api-changelog.md
+++ b/dev/api-changelog.md
@@ -1,5 +1,18 @@
 # API Changelog
 
+## CBBF-175: Fixed `ExplanationOfBenefit.diagnosis.type` Entries
+
+Several changes have been made to these entries:
+
+* The `Coding.system` has been changed.
+    * Previously: ``
+    * Corrected/current: `https://bluebutton.cms.gov/resources/codesystem/diagnosis-type`
+* The `Coding.code` values have been fixed.
+    * Previous format: `[CODE1]`
+    * Corrected/current format: `code1`
+        * In rare cases where there's more than one code, these will be captured in additional `ExplanationOfBenefit.diagnosis.type` entries.
+* The `Coding.display` values are included.
+
 ## CBBF-169: Fixed Money Codings
 
 [Money](http://hl7.org/fhir/STU3/datatypes.html#Money) values returned by the API were previously structured incorrectly per the FHIR specification and have now been corrected:


### PR DESCRIPTION
The previous code had a bug where all values were concat'd into a single Coding.code value of the form "[CODE1, CODE2]".

This is definitely a backwards-incompatible change, but I believe it's warranted given that:

1. There still aren't any production users of the API.
2. The current format is clearly a bug and invalid.
3. It's a minor enough change that it likely won't impact many applications.

As an aside, I think I'd still push for fixing it now, even if we already had production users.

https://issues.hhsdevcloud.us/browse/CBBF-175