### PR TITLE
BLUEBUTTON-200: Fix duplicate EOBs bug

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ClaimType.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ClaimType.java
@@ -14,6 +14,7 @@ import javax.persistence.metamodel.SingularAttribute;
 
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 
+import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.CarrierClaim;
 import gov.hhs.cms.bluebutton.data.model.rif.CarrierClaim_;
 import gov.hhs.cms.bluebutton.data.model.rif.DMEClaim;
@@ -36,26 +37,32 @@ import gov.hhs.cms.bluebutton.data.model.rif.SNFClaim_;
  * {@link ExplanationOfBenefitResourceProvider}.
  */
 enum ClaimType {
-	CARRIER(CarrierClaim.class, CarrierClaim_.claimId, CarrierClaimTransformer::transform, CarrierClaim_.lines),
+	CARRIER(CarrierClaim.class, CarrierClaim_.claimId, CarrierClaim_.beneficiaryId, CarrierClaimTransformer::transform,
+			CarrierClaim_.lines),
 	
-	DME(DMEClaim.class, DMEClaim_.claimId, DMEClaimTransformer::transform, DMEClaim_.lines),
+	DME(DMEClaim.class, DMEClaim_.claimId, CarrierClaim_.beneficiaryId, DMEClaimTransformer::transform,
+			DMEClaim_.lines),
 	
-	HHA(HHAClaim.class, HHAClaim_.claimId, HHAClaimTransformer::transform, HHAClaim_.lines),
+	HHA(HHAClaim.class, HHAClaim_.claimId, HHAClaim_.beneficiaryId, HHAClaimTransformer::transform, HHAClaim_.lines),
 
-	HOSPICE(HospiceClaim.class, HospiceClaim_.claimId, HospiceClaimTransformer::transform, HospiceClaim_.lines),
+	HOSPICE(HospiceClaim.class, HospiceClaim_.claimId, HospiceClaim_.beneficiaryId, HospiceClaimTransformer::transform,
+			HospiceClaim_.lines),
 
-	INPATIENT(InpatientClaim.class, InpatientClaim_.claimId, InpatientClaimTransformer::transform,
+	INPATIENT(InpatientClaim.class, InpatientClaim_.claimId, InpatientClaim_.beneficiaryId,
+			InpatientClaimTransformer::transform,
 			InpatientClaim_.lines),
 
-	OUTPATIENT(OutpatientClaim.class, OutpatientClaim_.claimId, OutpatientClaimTransformer::transform,
+	OUTPATIENT(OutpatientClaim.class, OutpatientClaim_.claimId, OutpatientClaim_.beneficiaryId,
+			OutpatientClaimTransformer::transform,
 			OutpatientClaim_.lines),
 
-	PDE(PartDEvent.class, PartDEvent_.eventId, PartDEventTransformer::transform),
+	PDE(PartDEvent.class, PartDEvent_.eventId, PartDEvent_.beneficiaryId, PartDEventTransformer::transform),
 
-	SNF(SNFClaim.class, SNFClaim_.claimId, SNFClaimTransformer::transform, SNFClaim_.lines);
+	SNF(SNFClaim.class, SNFClaim_.claimId, SNFClaim_.beneficiaryId, SNFClaimTransformer::transform, SNFClaim_.lines);
 
 	private final Class<?> entityClass;
 	private final SingularAttribute<?, ?> entityIdAttribute;
+	private final SingularAttribute<?, String> entityBeneficiaryIdAttribute;
 	private final Function<Object, ExplanationOfBenefit> transformer;
 	private final Collection<PluralAttribute<?, ?, ?>> entityLazyAttributes;
 
@@ -66,15 +73,19 @@ enum ClaimType {
 	 *            the value to use for {@link #getEntityClass()}
 	 * @param entityIdAttribute
 	 *            the value to use for {@link #getEntityIdAttribute()}
+	 * @param entityBeneficiaryIdAttribute
+	 *            the value to use for {@link #getEntityBeneficiaryIdAttribute()}
 	 * @param transformer
 	 *            the value to use for {@link #getTransformer()}
 	 * @param entityLazyAttributes
 	 *            the value to use for {@link #getEntityLazyAttributes()}
 	 */
 	private ClaimType(Class<?> entityClass, SingularAttribute<?, ?> entityIdAttribute,
+			SingularAttribute<?, String> entityBeneficiaryIdAttribute,
 			Function<Object, ExplanationOfBenefit> transformer, PluralAttribute<?, ?, ?>... entityLazyAttributes) {
 		this.entityClass = entityClass;
 		this.entityIdAttribute = entityIdAttribute;
+		this.entityBeneficiaryIdAttribute = entityBeneficiaryIdAttribute;
 		this.transformer = transformer;
 		this.entityLazyAttributes = entityLazyAttributes != null
 				? Collections.unmodifiableCollection(Arrays.asList(entityLazyAttributes)) : Collections.emptyList();
@@ -93,6 +104,14 @@ enum ClaimType {
 	 */
 	public SingularAttribute<?, ?> getEntityIdAttribute() {
 		return entityIdAttribute;
+	}
+
+	/**
+	 * @return the JPA {@link Entity} field that is a (foreign keyed) reference to
+	 *         {@link Beneficiary#getBeneficiaryId()}
+	 */
+	public SingularAttribute<?, String> getEntityBeneficiaryIdAttribute() {
+		return entityBeneficiaryIdAttribute;
 	}
 
 	/**

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ClaimType.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ClaimType.java
@@ -40,8 +40,7 @@ enum ClaimType {
 	CARRIER(CarrierClaim.class, CarrierClaim_.claimId, CarrierClaim_.beneficiaryId, CarrierClaimTransformer::transform,
 			CarrierClaim_.lines),
 	
-	DME(DMEClaim.class, DMEClaim_.claimId, CarrierClaim_.beneficiaryId, DMEClaimTransformer::transform,
-			DMEClaim_.lines),
+	DME(DMEClaim.class, DMEClaim_.claimId, DMEClaim_.beneficiaryId, DMEClaimTransformer::transform, DMEClaim_.lines),
 	
 	HHA(HHAClaim.class, HHAClaim_.claimId, HHAClaim_.beneficiaryId, HHAClaimTransformer::transform, HHAClaim_.lines),
 

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProvider.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProvider.java
@@ -205,7 +205,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 		CriteriaQuery<CarrierClaim> criteria = builder.createQuery(CarrierClaim.class);
 		Root<CarrierClaim> root = criteria.from(CarrierClaim.class);
 		ClaimType.CARRIER.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root);
+		criteria.select(root).distinct(true);
 
 		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
 				root.get(CarrierClaim_.beneficiaryId));
@@ -230,7 +230,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 		CriteriaQuery<DMEClaim> criteria = builder.createQuery(DMEClaim.class);
 		Root<DMEClaim> root = criteria.from(DMEClaim.class);
 		ClaimType.DME.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root);
+		criteria.select(root).distinct(true);
 
 		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
 				root.get(DMEClaim_.beneficiaryId));
@@ -253,7 +253,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 		CriteriaQuery<HHAClaim> criteria = builder.createQuery(HHAClaim.class);
 		Root<HHAClaim> root = criteria.from(HHAClaim.class);
 		ClaimType.HHA.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root);
+		criteria.select(root).distinct(true);
 
 		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
 				root.get(HHAClaim_.beneficiaryId));
@@ -276,7 +276,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 		CriteriaQuery<HospiceClaim> criteria = builder.createQuery(HospiceClaim.class);
 		Root<HospiceClaim> root = criteria.from(HospiceClaim.class);
 		ClaimType.HOSPICE.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root);
+		criteria.select(root).distinct(true);
 
 		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
 				root.get(HospiceClaim_.beneficiaryId));
@@ -299,7 +299,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 		CriteriaQuery<InpatientClaim> criteria = builder.createQuery(InpatientClaim.class);
 		Root<InpatientClaim> root = criteria.from(InpatientClaim.class);
 		ClaimType.INPATIENT.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root);
+		criteria.select(root).distinct(true);
 
 		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
 				root.get(InpatientClaim_.beneficiaryId));
@@ -323,7 +323,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 		CriteriaQuery<OutpatientClaim> criteria = builder.createQuery(OutpatientClaim.class);
 		Root<OutpatientClaim> root = criteria.from(OutpatientClaim.class);
 		ClaimType.OUTPATIENT.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root);
+		criteria.select(root).distinct(true);
 
 		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
 				root.get(OutpatientClaim_.beneficiaryId));
@@ -346,7 +346,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 		CriteriaQuery<PartDEvent> criteria = builder.createQuery(PartDEvent.class);
 		Root<PartDEvent> root = criteria.from(PartDEvent.class);
 		ClaimType.PDE.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root);
+		criteria.select(root).distinct(true);
 
 		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
 				root.get(PartDEvent_.beneficiaryId));
@@ -370,7 +370,7 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 		CriteriaQuery<SNFClaim> criteria = builder.createQuery(SNFClaim.class);
 		Root<SNFClaim> root = criteria.from(SNFClaim.class);
 		ClaimType.SNF.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root);
+		criteria.select(root).distinct(true);
 
 		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
 				root.get(SNFClaim_.beneficiaryId));

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProvider.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProvider.java
@@ -1,6 +1,5 @@
 package gov.hhs.cms.bluebutton.server.app.stu3.providers;
 
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -13,15 +12,13 @@ import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Root;
 import javax.persistence.metamodel.PluralAttribute;
+import javax.persistence.metamodel.SingularAttribute;
 
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import ca.uhn.fhir.model.primitive.IdDt;
@@ -32,22 +29,7 @@ import ca.uhn.fhir.rest.annotation.Search;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
-import gov.hhs.cms.bluebutton.data.model.rif.CarrierClaim;
-import gov.hhs.cms.bluebutton.data.model.rif.CarrierClaim_;
-import gov.hhs.cms.bluebutton.data.model.rif.DMEClaim;
-import gov.hhs.cms.bluebutton.data.model.rif.DMEClaim_;
-import gov.hhs.cms.bluebutton.data.model.rif.HHAClaim;
-import gov.hhs.cms.bluebutton.data.model.rif.HHAClaim_;
-import gov.hhs.cms.bluebutton.data.model.rif.HospiceClaim;
-import gov.hhs.cms.bluebutton.data.model.rif.HospiceClaim_;
-import gov.hhs.cms.bluebutton.data.model.rif.InpatientClaim;
-import gov.hhs.cms.bluebutton.data.model.rif.InpatientClaim_;
-import gov.hhs.cms.bluebutton.data.model.rif.OutpatientClaim;
-import gov.hhs.cms.bluebutton.data.model.rif.OutpatientClaim_;
-import gov.hhs.cms.bluebutton.data.model.rif.PartDEvent;
-import gov.hhs.cms.bluebutton.data.model.rif.PartDEvent_;
-import gov.hhs.cms.bluebutton.data.model.rif.SNFClaim;
-import gov.hhs.cms.bluebutton.data.model.rif.SNFClaim_;
+import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 
 /**
  * This FHIR {@link IResourceProvider} adds support for STU3
@@ -60,7 +42,6 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 	 * {@link ExplanationOfBenefit#getId()}s used in this application.
 	 */
 	private static final Pattern EOB_ID_PATTERN = Pattern.compile("(\\p{Alpha}+)-(\\p{Alnum}+)");
-	private static final Logger LOGGER = LoggerFactory.getLogger(ExplanationOfBenefitResourceProvider.class);
 
 	private EntityManager entityManager;
 
@@ -163,6 +144,8 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 	@Search
 	public List<ExplanationOfBenefit> findByPatient(
 			@RequiredParam(name = ExplanationOfBenefit.SP_PATIENT) ReferenceParam patient) {
+		String beneficiaryId = patient.getIdPart();
+
 		/*
 		 * The way our JPA/SQL schema is setup, we have to run a separate search
 		 * for each claim type, then combine the results. It's not super
@@ -170,238 +153,49 @@ public final class ExplanationOfBenefitResourceProvider implements IResourceProv
 		 */
 		List<ExplanationOfBenefit> eobs = new LinkedList<>();
 
-		eobs.addAll(findCarrierClaimsByPatient(patient).stream().map(ClaimType.CARRIER.getTransformer())
-				.collect(Collectors.toList()));
-		eobs.addAll(findDMEClaimsByPatient(patient).stream().map(ClaimType.DME.getTransformer())
-				.collect(Collectors.toList()));
-		eobs.addAll(findHHAClaimsByPatient(patient).stream().map(ClaimType.HHA.getTransformer())
-				.collect(Collectors.toList()));
-		eobs.addAll(findHospiceClaimsByPatient(patient).stream().map(ClaimType.HOSPICE.getTransformer())
-				.collect(Collectors.toList()));
-		eobs.addAll(findInpatientClaimsByPatient(patient).stream().map(ClaimType.INPATIENT.getTransformer())
-				.collect(Collectors.toList()));
-		eobs.addAll(findOutpatientClaimsByPatient(patient).stream()
-				.map(ClaimType.OUTPATIENT.getTransformer()).collect(Collectors.toList()));
-		eobs.addAll(findPartDEventsByPatient(patient).stream().map(ClaimType.PDE.getTransformer())
-				.collect(Collectors.toList()));
-		eobs.addAll(findSNFClaimsByPatient(patient).stream().map(ClaimType.SNF.getTransformer())
-				.collect(Collectors.toList()));
+		eobs.addAll(transformToEobs(ClaimType.CARRIER, findClaimTypeByPatient(ClaimType.CARRIER, beneficiaryId)));
+		eobs.addAll(transformToEobs(ClaimType.DME, findClaimTypeByPatient(ClaimType.DME, beneficiaryId)));
+		eobs.addAll(transformToEobs(ClaimType.HHA, findClaimTypeByPatient(ClaimType.HHA, beneficiaryId)));
+		eobs.addAll(transformToEobs(ClaimType.HOSPICE, findClaimTypeByPatient(ClaimType.HOSPICE, beneficiaryId)));
+		eobs.addAll(transformToEobs(ClaimType.INPATIENT, findClaimTypeByPatient(ClaimType.INPATIENT, beneficiaryId)));
+		eobs.addAll(transformToEobs(ClaimType.OUTPATIENT, findClaimTypeByPatient(ClaimType.OUTPATIENT, beneficiaryId)));
+		eobs.addAll(transformToEobs(ClaimType.PDE, findClaimTypeByPatient(ClaimType.PDE, beneficiaryId)));
+		eobs.addAll(transformToEobs(ClaimType.SNF, findClaimTypeByPatient(ClaimType.SNF, beneficiaryId)));
 		 
 		return eobs;
 	}
 
-
 	/**
-	 * @param patient
-	 *            a {@link ReferenceParam} for the
-	 *            {@link ExplanationOfBenefit#getPatient()} to try and find
-	 *            matches for {@link CarrierClaim}s
-	 * @return the {@link CarrierClaim}s
+	 * @param claimType
+	 *            the {@link ClaimType} to find
+	 * @param patientId
+	 *            the {@link Beneficiary#getBeneficiaryId()} to filter by
+	 * @return the matching claim/event entities
 	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private Collection<CarrierClaim> findCarrierClaimsByPatient(ReferenceParam patient) {
-		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private <T> List<T> findClaimTypeByPatient(ClaimType claimType, String patientId) {
+		CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
 
-		CriteriaQuery<CarrierClaim> criteria = builder.createQuery(CarrierClaim.class);
-		Root<CarrierClaim> root = criteria.from(CarrierClaim.class);
-		ClaimType.CARRIER.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
+		CriteriaQuery criteria = criteriaBuilder.createQuery((Class) claimType.getEntityClass());
+		Root root = criteria.from((Class) claimType.getEntityClass());
+		claimType.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
 		criteria.select(root).distinct(true);
+		criteria.where(criteriaBuilder.equal(root.get((SingularAttribute) claimType.getEntityBeneficiaryIdAttribute()),
+				patientId));
 
-		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
-				root.get(CarrierClaim_.beneficiaryId));
-
-		List<CarrierClaim> claimEntities = entityManager.createQuery(criteriaQuery).getResultList();
-		return claimEntities;
-	}
-
-
-
-	/**
-	 * @param patient
-	 *            a {@link ReferenceParam} for the
-	 *            {@link ExplanationOfBenefit#getPatient()} to try and find
-	 *            matches for {@link DMEClaim}s
-	 * @return the {@link DMEClaim}s
-	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private Collection<DMEClaim> findDMEClaimsByPatient(ReferenceParam patient) {
-		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-
-		CriteriaQuery<DMEClaim> criteria = builder.createQuery(DMEClaim.class);
-		Root<DMEClaim> root = criteria.from(DMEClaim.class);
-		ClaimType.DME.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root).distinct(true);
-
-		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
-				root.get(DMEClaim_.beneficiaryId));
-
-		List<DMEClaim> claimEntities = entityManager.createQuery(criteriaQuery).getResultList();
+		List claimEntities = entityManager.createQuery(criteria).getResultList();
 		return claimEntities;
 	}
 
 	/**
-	 * @param patient
-	 *            a {@link ReferenceParam} for the
-	 *            {@link ExplanationOfBenefit#getPatient()} to try and find
-	 *            matches for {@link HHAClaim}s
-	 * @return the {@link HHAClaim}s
+	 * @param claimType
+	 *            the {@link ClaimType} being transformed
+	 * @param claims
+	 *            the claims/events to transform
+	 * @return the transformed {@link ExplanationOfBenefit} instances, one for each
+	 *         specified claim/event
 	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private Collection<HHAClaim> findHHAClaimsByPatient(ReferenceParam patient) {
-		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-
-		CriteriaQuery<HHAClaim> criteria = builder.createQuery(HHAClaim.class);
-		Root<HHAClaim> root = criteria.from(HHAClaim.class);
-		ClaimType.HHA.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root).distinct(true);
-
-		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
-				root.get(HHAClaim_.beneficiaryId));
-
-		List<HHAClaim> claimEntities = entityManager.createQuery(criteriaQuery).getResultList();
-		return claimEntities;
-	}
-
-	/**
-	 * @param patient
-	 *            a {@link ReferenceParam} for the
-	 *            {@link ExplanationOfBenefit#getPatient()} to try and find
-	 *            matches for {@link HospiceClaim}s
-	 * @return the {@link HospiceClaim}s
-	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private Collection<HospiceClaim> findHospiceClaimsByPatient(ReferenceParam patient) {
-		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-
-		CriteriaQuery<HospiceClaim> criteria = builder.createQuery(HospiceClaim.class);
-		Root<HospiceClaim> root = criteria.from(HospiceClaim.class);
-		ClaimType.HOSPICE.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root).distinct(true);
-
-		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
-				root.get(HospiceClaim_.beneficiaryId));
-
-		List<HospiceClaim> claimEntities = entityManager.createQuery(criteriaQuery).getResultList();
-		return claimEntities;
-	}
-
-	/**
-	 * @param patient
-	 *            a {@link ReferenceParam} for the
-	 *            {@link ExplanationOfBenefit#getPatient()} to try and find
-	 *            matches for {@link InpatientClaim}s
-	 * @return the {@link InpatientClaim}s
-	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private Collection<InpatientClaim> findInpatientClaimsByPatient(ReferenceParam patient) {
-		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-
-		CriteriaQuery<InpatientClaim> criteria = builder.createQuery(InpatientClaim.class);
-		Root<InpatientClaim> root = criteria.from(InpatientClaim.class);
-		ClaimType.INPATIENT.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root).distinct(true);
-
-		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
-				root.get(InpatientClaim_.beneficiaryId));
-
-		List<InpatientClaim> claimEntities = entityManager.createQuery(criteriaQuery).getResultList();
-
-		return claimEntities;
-	}
-
-	/**
-	 * @param patient
-	 *            a {@link ReferenceParam} for the
-	 *            {@link ExplanationOfBenefit#getPatient()} to try and find
-	 *            matches for {@link OutpatientClaim}s
-	 * @return the {@link OutpatientClaim}s
-	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private Collection<OutpatientClaim> findOutpatientClaimsByPatient(ReferenceParam patient) {
-		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-
-		CriteriaQuery<OutpatientClaim> criteria = builder.createQuery(OutpatientClaim.class);
-		Root<OutpatientClaim> root = criteria.from(OutpatientClaim.class);
-		ClaimType.OUTPATIENT.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root).distinct(true);
-
-		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
-				root.get(OutpatientClaim_.beneficiaryId));
-
-		List<OutpatientClaim> claimEntities = entityManager.createQuery(criteriaQuery).getResultList();
-		return claimEntities;
-	}
-
-	/**
-	 * @param patient
-	 *            a {@link ReferenceParam} for the
-	 *            {@link ExplanationOfBenefit#getPatient()} to try and find
-	 *            matches for {@link PartDEvent}s
-	 * @return the {@link PartDEvent}s
-	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private Collection<PartDEvent> findPartDEventsByPatient(ReferenceParam patient) {
-		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-
-		CriteriaQuery<PartDEvent> criteria = builder.createQuery(PartDEvent.class);
-		Root<PartDEvent> root = criteria.from(PartDEvent.class);
-		ClaimType.PDE.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root).distinct(true);
-
-		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
-				root.get(PartDEvent_.beneficiaryId));
-
-		List<PartDEvent> claimEntities = entityManager.createQuery(criteriaQuery).getResultList();
-
-		return claimEntities;
-	}
-
-	/**
-	 * @param patient
-	 *            a {@link ReferenceParam} for the
-	 *            {@link ExplanationOfBenefit#getPatient()} to try and find
-	 *            matches for {@link SNFClaim}s
-	 * @return the {@link SNFClaim}s
-	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private Collection<SNFClaim> findSNFClaimsByPatient(ReferenceParam patient) {
-		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-
-		CriteriaQuery<SNFClaim> criteria = builder.createQuery(SNFClaim.class);
-		Root<SNFClaim> root = criteria.from(SNFClaim.class);
-		ClaimType.SNF.getEntityLazyAttributes().stream().forEach(a -> root.fetch((PluralAttribute) a));
-		criteria.select(root).distinct(true);
-
-		CriteriaQuery criteriaQuery = createSearchCriteria(criteria, patient, root, builder,
-				root.get(SNFClaim_.beneficiaryId));
-
-		List<SNFClaim> claimEntities = entityManager.createQuery(criteriaQuery).getResultList();
-
-		return claimEntities;
-	}
-
-	/**
-	 * @param criteria
-	 *            {@link CriteriaQuery} for the search
-	 * @param patient
-	 *            a {@link ReferenceParam} for the
-	 *            {@link ExplanationOfBenefit#getPatient()} to try and find
-	 *            matches for {@link PartDEvent}s
-	 * @param root
-	 *            {@link Root} for the search
-	 * @param builder
-	 *            {@link CriteriaBuilder} for the search
-	 * @param beneficiaryIdPath
-	 *            {@link Path} for the beneficiaryId
-	 * @return the {@link CriteriaQuery}
-	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private CriteriaQuery createSearchCriteria(CriteriaQuery criteria, ReferenceParam patient, Root root,
-			CriteriaBuilder builder, Path beneficiaryIdPath) {
-		
-		// FIXME completely ignores the patient param's system
-
-		criteria.where(builder.equal(beneficiaryIdPath, patient.getIdPart()));
-		return criteria;
+	private List<ExplanationOfBenefit> transformToEobs(ClaimType claimType, List<?> claims) {
+		return claims.stream().map(claimType.getTransformer()).collect(Collectors.toList());
 	}
 }

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
@@ -1,9 +1,12 @@
 package gov.hhs.cms.bluebutton.server.app.stu3.providers;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.exceptions.FHIRException;
@@ -440,6 +443,47 @@ public final class ExplanationOfBenefitResourceProviderIT {
 						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.SNF.name()))
 				.findFirst().get();
 		SNFClaimTransformerTest.assertMatches(snfClaim, snfClaimFromSearchResult);
+	}
+
+	/**
+	 * <p>
+	 * Verifies that
+	 * {@link ExplanationOfBenefitResourceProvider#findByPatient(ca.uhn.fhir.rest.param.ReferenceParam)}
+	 * doesn't return duplicate results.
+	 * </p>
+	 * <p>
+	 * This is a regression test case for TODO.
+	 * </p>
+	 *
+	 * @throws FHIRException
+	 *             (indicates test failure)
+	 */
+	@Test
+	public void searchForEobsHasNoDupes() throws FHIRException {
+		List<Object> loadedRecords = ServerTestUtils
+				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_B.getResources()));
+		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+
+		loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r).forEach(beneficiary -> {
+			Bundle searchResults = fhirClient.search().forResource(ExplanationOfBenefit.class)
+					.where(ExplanationOfBenefit.PATIENT.hasId(TransformerUtils.buildPatientId(beneficiary)))
+					.returnBundle(Bundle.class).execute();
+			Assert.assertNotNull(searchResults);
+
+			/*
+			 * Verify that the returned Bundle doesn't have any resources with duplicate
+			 * IDs.
+			 */
+			Set<String> claimIds = new HashSet<>();
+			for (BundleEntryComponent searchResultEntry : searchResults.getEntry()) {
+				String resourceId = searchResultEntry.getResource().getId();
+				if (claimIds.contains(resourceId))
+					Assert.assertFalse(claimIds.contains(resourceId));
+				claimIds.add(resourceId);
+			}
+			if (searchResults.getTotal() > 0)
+				Assert.assertFalse(claimIds.isEmpty());
+		});
 	}
 
 	/**

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExplanationOfBenefitResourceProviderIT.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Bundle.BundleEntryComponent;
@@ -366,83 +367,40 @@ public final class ExplanationOfBenefitResourceProviderIT {
 
 		CarrierClaim carrierClaim = loadedRecords.stream().filter(r -> r instanceof CarrierClaim)
 				.map(r -> (CarrierClaim) r).findFirst().get();
-		ExplanationOfBenefit carrierClaimFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
-				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-				.map(e -> (ExplanationOfBenefit) e.getResource())
-				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.CARRIER.name()))
-				.findFirst().get();
-		CarrierClaimTransformerTest.assertMatches(carrierClaim, carrierClaimFromSearchResult);
+		Assert.assertEquals(1, filterToClaimType(searchResults, ClaimType.CARRIER).size());
+		CarrierClaimTransformerTest.assertMatches(carrierClaim,
+				filterToClaimType(searchResults, ClaimType.CARRIER).get(0));
 
 		DMEClaim dmeClaim = loadedRecords.stream().filter(r -> r instanceof DMEClaim).map(r -> (DMEClaim) r).findFirst()
 				.get();
-		ExplanationOfBenefit dmeClaimFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
-				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-				.map(e -> (ExplanationOfBenefit) e.getResource())
-				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.DME.name()))
-				.findFirst().get();
-		DMEClaimTransformerTest.assertMatches(dmeClaim, dmeClaimFromSearchResult);
+		DMEClaimTransformerTest.assertMatches(dmeClaim, filterToClaimType(searchResults, ClaimType.DME).get(0));
 
 		HHAClaim hhaClaim = loadedRecords.stream().filter(r -> r instanceof HHAClaim).map(r -> (HHAClaim) r).findFirst()
 				.get();
-		ExplanationOfBenefit hhaClaimFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
-				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-				.map(e -> (ExplanationOfBenefit) e.getResource())
-				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.HHA.name()))
-				.findFirst().get();
-		HHAClaimTransformerTest.assertMatches(hhaClaim, hhaClaimFromSearchResult);
+		HHAClaimTransformerTest.assertMatches(hhaClaim, filterToClaimType(searchResults, ClaimType.HHA).get(0));
 
 		HospiceClaim hospiceClaim = loadedRecords.stream().filter(r -> r instanceof HospiceClaim)
 				.map(r -> (HospiceClaim) r).findFirst().get();
-		ExplanationOfBenefit hospiceClaimFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
-				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-				.map(e -> (ExplanationOfBenefit) e.getResource())
-				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.HOSPICE.name()))
-				.findFirst().get();
-		HospiceClaimTransformerTest.assertMatches(hospiceClaim, hospiceClaimFromSearchResult);
+		HospiceClaimTransformerTest.assertMatches(hospiceClaim,
+				filterToClaimType(searchResults, ClaimType.HOSPICE).get(0));
 
 		InpatientClaim inpatientClaim = loadedRecords.stream().filter(r -> r instanceof InpatientClaim)
 				.map(r -> (InpatientClaim) r).findFirst().get();
-		ExplanationOfBenefit inpatientClaimFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
-				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-				.map(e -> (ExplanationOfBenefit) e.getResource())
-				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.INPATIENT.name()))
-				.findFirst().get();
-		InpatientClaimTransformerTest.assertMatches(inpatientClaim, inpatientClaimFromSearchResult);
+		InpatientClaimTransformerTest.assertMatches(inpatientClaim,
+				filterToClaimType(searchResults, ClaimType.INPATIENT).get(0));
 
 		OutpatientClaim outpatientClaim = loadedRecords.stream().filter(r -> r instanceof OutpatientClaim)
 				.map(r -> (OutpatientClaim) r).findFirst().get();
-		ExplanationOfBenefit outpatientClaimFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
-				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-				.map(e -> (ExplanationOfBenefit) e.getResource())
-				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.OUTPATIENT.name()))
-				.findFirst().get();
-		OutpatientClaimTransformerTest.assertMatches(outpatientClaim, outpatientClaimFromSearchResult);
+		OutpatientClaimTransformerTest.assertMatches(outpatientClaim,
+				filterToClaimType(searchResults, ClaimType.OUTPATIENT).get(0));
 
 		PartDEvent partDEvent = loadedRecords.stream().filter(r -> r instanceof PartDEvent).map(r -> (PartDEvent) r)
 				.findFirst().get();
-		ExplanationOfBenefit partDEventFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
-				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-				.map(e -> (ExplanationOfBenefit) e.getResource())
-				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.PDE.name()))
-				.findFirst().get();
-		PartDEventTransformerTest.assertMatches(partDEvent, partDEventFromSearchResult);
+		PartDEventTransformerTest.assertMatches(partDEvent, filterToClaimType(searchResults, ClaimType.PDE).get(0));
 
 		SNFClaim snfClaim = loadedRecords.stream().filter(r -> r instanceof SNFClaim).map(r -> (SNFClaim) r).findFirst()
 				.get();
-		ExplanationOfBenefit snfClaimFromSearchResult = (ExplanationOfBenefit) searchResults.getEntry().stream()
-				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
-				.map(e -> (ExplanationOfBenefit) e.getResource())
-				.filter(e -> TransformerTestUtils.isCodeInConcept(e.getType(),
-						TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, ClaimType.SNF.name()))
-				.findFirst().get();
-		SNFClaimTransformerTest.assertMatches(snfClaim, snfClaimFromSearchResult);
+		SNFClaimTransformerTest.assertMatches(snfClaim, filterToClaimType(searchResults, ClaimType.SNF).get(0));
 	}
 
 	/**
@@ -511,5 +469,23 @@ public final class ExplanationOfBenefitResourceProviderIT {
 	@After
 	public void cleanDatabaseServerAfterEachTestCase() {
 		ServerTestUtils.cleanDatabaseServer();
+	}
+
+	/**
+	 * @param bundle
+	 *            the {@link Bundle} to filter
+	 * @param claimType
+	 *            the {@link ClaimType} to use as a filter
+	 * @return a filtered {@link List} of the {@link ExplanationOfBenefit}s from the
+	 *         specified {@link Bundle} that match the specified {@link ClaimType}
+	 */
+	private static List<ExplanationOfBenefit> filterToClaimType(Bundle bundle, ClaimType claimType) {
+		List<ExplanationOfBenefit> carrierClaimResults = bundle.getEntry().stream()
+				.filter(e -> e.getResource() instanceof ExplanationOfBenefit)
+				.map(e -> (ExplanationOfBenefit) e.getResource()).filter(e -> {
+					return TransformerTestUtils.isCodeInConcept(e.getType(),
+							TransformerConstants.CODING_SYSTEM_BBAPI_EOB_TYPE, claimType.name());
+				}).collect(Collectors.toList());
+		return carrierClaimResults;
 	}
 }


### PR DESCRIPTION
Fixed the bug in https://jira.cms.gov/browse/BLUEBUTTON-200. This is/was caused by a pretty surprising (to me, at least) JPA problem, where non-lazy-load queries across multiple entities (e.g. an `INNER JOIN` like we're doing here) cause duplicate top-level entities to be returned by JPA: one for each of the result set rows. In this specific case, we were getting a `FooClaim` instance for every `FooClaimLine` row that was found. This is often referred to as the "N+1" problem with JPA, for reasons that escape me.

While I was in there, I also cleaned up the related code quite a bit, as it'd started to get out of hand.