### PR TITLE
BLUEBUTTON-130: Create reference links and response based on base path

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/BlueButtonServerInitializer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/BlueButtonServerInitializer.java
@@ -63,7 +63,7 @@ public final class BlueButtonServerInitializer implements WebApplicationInitiali
 		ServletRegistration.Dynamic cxfServletReg = servletContext.addServlet("fhirStu3Servlet", stu3Servlet);
 		cxfServletReg.setLoadOnStartup(1);
 		cxfServletReg.addMapping("/v1/fhir/*");
-		cxfServletReg.addMapping("/baseDstu3/*");
+		// cxfServletReg.addMapping("/baseDstu3/*");
 
 		/*
 		 * Register the MetricRegistry and HealthCheckRegistry into the ServletContext,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/BlueButtonServerInitializer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/BlueButtonServerInitializer.java
@@ -62,7 +62,7 @@ public final class BlueButtonServerInitializer implements WebApplicationInitiali
 		BlueButtonStu3Server stu3Servlet = new BlueButtonStu3Server();
 		ServletRegistration.Dynamic cxfServletReg = servletContext.addServlet("fhirStu3Servlet", stu3Servlet);
 		cxfServletReg.setLoadOnStartup(1);
-		cxfServletReg.addMapping("/baseDstu3/*");
+		cxfServletReg.addMapping("/v1/fhir/*");
 
 		/*
 		 * Register the MetricRegistry and HealthCheckRegistry into the ServletContext,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/BlueButtonServerInitializer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/BlueButtonServerInitializer.java
@@ -63,7 +63,7 @@ public final class BlueButtonServerInitializer implements WebApplicationInitiali
 		ServletRegistration.Dynamic cxfServletReg = servletContext.addServlet("fhirStu3Servlet", stu3Servlet);
 		cxfServletReg.setLoadOnStartup(1);
 		cxfServletReg.addMapping("/v1/fhir/*");
-		// cxfServletReg.addMapping("/baseDstu3/*");
+		cxfServletReg.addMapping("/baseDstu3/*");
 
 		/*
 		 * Register the MetricRegistry and HealthCheckRegistry into the ServletContext,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/BlueButtonServerInitializer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/BlueButtonServerInitializer.java
@@ -63,6 +63,7 @@ public final class BlueButtonServerInitializer implements WebApplicationInitiali
 		ServletRegistration.Dynamic cxfServletReg = servletContext.addServlet("fhirStu3Servlet", stu3Servlet);
 		cxfServletReg.setLoadOnStartup(1);
 		cxfServletReg.addMapping("/v1/fhir/*");
+		cxfServletReg.addMapping("/baseDstu3/*");
 
 		/*
 		 * Register the MetricRegistry and HealthCheckRegistry into the ServletContext,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/BlueButtonServerInitializer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/BlueButtonServerInitializer.java
@@ -62,7 +62,7 @@ public final class BlueButtonServerInitializer implements WebApplicationInitiali
 		BlueButtonStu3Server stu3Servlet = new BlueButtonStu3Server();
 		ServletRegistration.Dynamic cxfServletReg = servletContext.addServlet("fhirStu3Servlet", stu3Servlet);
 		cxfServletReg.setLoadOnStartup(1);
-		cxfServletReg.addMapping("/v1/fhir/*");
+		cxfServletReg.addMapping("/baseDstu3/*");
 
 		/*
 		 * Register the MetricRegistry and HealthCheckRegistry into the ServletContext,

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
@@ -39,6 +39,7 @@ import com.codahale.metrics.MetricRegistry;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.IGenericClient;
 import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
+import ca.uhn.fhir.rest.server.EncodingEnum;
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.RifFileEvent;
 import gov.hhs.cms.bluebutton.data.model.rif.RifFileRecords;
@@ -106,7 +107,7 @@ public final class ServerTestUtils {
 		ctx.getRestfulClientFactory().setHttpClient(httpClient);
 
 		IGenericClient client = ctx.newRestfulGenericClient(fhirBaseUrl);
-
+		client.setEncoding(EncodingEnum.JSON);
 		/*
 		 * The FHIR client logging (for tests) can be managed via the
 		 * `src/test/resources/logback-test.xml` file.

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
@@ -72,7 +72,7 @@ public final class ServerTestUtils {
 	 */
 	public static IGenericClient createFhirClient(Optional<ClientSslIdentity> clientSslIdentity) {
 		// Figure out where the test server is running.
-		String fhirBaseUrl = String.format("%s/v1/fhir", getServerBaseUrl());
+		String fhirBaseUrl = String.format("%s/baseDstu3", getServerBaseUrl());
 
 		/*
 		 * We need to override the FHIR client's SSLContext. Unfortunately, that

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
@@ -73,7 +73,7 @@ public final class ServerTestUtils {
 	 */
 	public static IGenericClient createFhirClient(Optional<ClientSslIdentity> clientSslIdentity) {
 		// Figure out where the test server is running.
-		String fhirBaseUrl = String.format("%s/baseDstu3", getServerBaseUrl());
+		String fhirBaseUrl = String.format("%s/v1/fhir", getServerBaseUrl());
 
 		/*
 		 * We need to override the FHIR client's SSLContext. Unfortunately, that

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
@@ -39,6 +39,7 @@ import com.codahale.metrics.MetricRegistry;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.IGenericClient;
 import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
+import ca.uhn.fhir.rest.server.EncodingEnum;
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.RifFileEvent;
 import gov.hhs.cms.bluebutton.data.model.rif.RifFileRecords;
@@ -107,6 +108,7 @@ public final class ServerTestUtils {
 
 		IGenericClient client = ctx.newRestfulGenericClient(fhirBaseUrl);
 
+		client.setEncoding(EncodingEnum.JSON);
 		/*
 		 * The FHIR client logging (for tests) can be managed via the
 		 * `src/test/resources/logback-test.xml` file.

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
@@ -39,7 +39,6 @@ import com.codahale.metrics.MetricRegistry;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.IGenericClient;
 import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
-import ca.uhn.fhir.rest.server.EncodingEnum;
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.RifFileEvent;
 import gov.hhs.cms.bluebutton.data.model.rif.RifFileRecords;
@@ -107,7 +106,7 @@ public final class ServerTestUtils {
 		ctx.getRestfulClientFactory().setHttpClient(httpClient);
 
 		IGenericClient client = ctx.newRestfulGenericClient(fhirBaseUrl);
-		client.setEncoding(EncodingEnum.JSON);
+
 		/*
 		 * The FHIR client logging (for tests) can be managed via the
 		 * `src/test/resources/logback-test.xml` file.

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/ServerTestUtils.java
@@ -39,7 +39,6 @@ import com.codahale.metrics.MetricRegistry;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.IGenericClient;
 import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
-import ca.uhn.fhir.rest.server.EncodingEnum;
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.RifFileEvent;
 import gov.hhs.cms.bluebutton.data.model.rif.RifFileRecords;
@@ -108,7 +107,6 @@ public final class ServerTestUtils {
 
 		IGenericClient client = ctx.newRestfulGenericClient(fhirBaseUrl);
 
-		client.setEncoding(EncodingEnum.JSON);
 		/*
 		 * The FHIR client logging (for tests) can be managed via the
 		 * `src/test/resources/logback-test.xml` file.

--- a/bluebutton-server-app/src/test/resources/logback-test.xml
+++ b/bluebutton-server-app/src/test/resources/logback-test.xml
@@ -11,7 +11,7 @@
 	
 	<!-- Set to 'debug' to log FHIR test client request and response summaries,
 		or to 'trace' to log the full requests and responses. -->
-	<logger name="gov.hhs.cms.bluebutton.server.app.ServerTestUtils" level="info" />
+	<logger name="gov.hhs.cms.bluebutton.server.app.ServerTestUtils" level="trace" />
 
 	<root level="info">
 		<appender-ref ref="STDOUT" />

--- a/bluebutton-server-app/src/test/resources/logback-test.xml
+++ b/bluebutton-server-app/src/test/resources/logback-test.xml
@@ -11,7 +11,7 @@
 	
 	<!-- Set to 'debug' to log FHIR test client request and response summaries,
 		or to 'trace' to log the full requests and responses. -->
-	<logger name="gov.hhs.cms.bluebutton.server.app.ServerTestUtils" level="trace" />
+	<logger name="gov.hhs.cms.bluebutton.server.app.ServerTestUtils" level="debug" />
 
 	<root level="info">
 		<appender-ref ref="STDOUT" />

--- a/bluebutton-server-app/src/test/resources/logback-test.xml
+++ b/bluebutton-server-app/src/test/resources/logback-test.xml
@@ -11,7 +11,7 @@
 	
 	<!-- Set to 'debug' to log FHIR test client request and response summaries,
 		or to 'trace' to log the full requests and responses. -->
-	<logger name="gov.hhs.cms.bluebutton.server.app.ServerTestUtils" level="debug" />
+	<logger name="gov.hhs.cms.bluebutton.server.app.ServerTestUtils" level="info" />
 
 	<root level="info">
 		<appender-ref ref="STDOUT" />

--- a/bluebutton-server-app/src/test/resources/logback-test.xml
+++ b/bluebutton-server-app/src/test/resources/logback-test.xml
@@ -11,7 +11,7 @@
 	
 	<!-- Set to 'debug' to log FHIR test client request and response summaries,
 		or to 'trace' to log the full requests and responses. -->
-	<logger name="gov.hhs.cms.bluebutton.server.app.ServerTestUtils" level="trace" />
+	<logger name="gov.hhs.cms.bluebutton.server.app.ServerTestUtils" level="info" />
 
 	<root level="info">
 		<appender-ref ref="STDOUT" />


### PR DESCRIPTION
Changing the path mapping from /baseDstu3/ to /v1/fhir/ so that the frontend does not need to replace the URL values in the fhir response we are sending to them.