### PR TITLE
Revert "BLUEBUTTON-239: Remove HICN hash from returned EOBs"

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
@@ -48,6 +48,8 @@ final class BeneficiaryTransformer {
 		patient.setId(beneficiary.getBeneficiaryId());
 		patient.addIdentifier(
 				TransformerUtils.createIdentifier(CcwCodebookVariable.BENE_ID, beneficiary.getBeneficiaryId()));
+		patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH)
+				.setValue(beneficiary.getHicn());
 
 		patient.addAddress().setState(beneficiary.getStateCode()).setDistrict(beneficiary.getCountyCode())
 				.setPostalCode(beneficiary.getPostalCode());

--- a/dev/api-changelog.md
+++ b/dev/api-changelog.md
@@ -1,11 +1,5 @@
 # API Changelog
 
-## BLUEBUTTON-239: Remove the HICN Hash from `Patient.identifier`
-
-Previously, EOB responses had included a one-way cryptographic hash of each beneficiary's current HICN.
-
-That field has now been removed from the returned `Patient` responses. It is still used behind-the-scenes, but did not need to be exposed otherwise.
-
 ## BLUEBUTTON-147: Display ICD and Procedure code displays in EOB
 
 Several changes have been made to these entries:


### PR DESCRIPTION
Reverts CMSgov/bluebutton-data-server#104

@dho937 Apologies, but reverting since that earlier change never got the product management signoff it needed.

And thinking about it some more, I think it's ultimately not as big a deal, anymore. Happy to discuss why offline.