### PR TITLE
BLUEBUTTON-480: Fix test failure and update change log

### DIFF
--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerTestUtils.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerTestUtils.java
@@ -370,7 +370,7 @@ final class TransformerTestUtils {
 		if(expectedCode instanceof Character)
 			Assert.assertEquals(((Character) expectedCode).toString(), actual.getCode());
 		else if (expectedCode instanceof String)
-			Assert.assertEquals(expectedCode, actual.getCode());
+			Assert.assertEquals(((String) expectedCode).trim(), actual.getCode());
 		else
 			throw new BadCodeMonkeyException();
 	}

--- a/dev/api-changelog.md
+++ b/dev/api-changelog.md
@@ -1,5 +1,11 @@
 # API Changelog
 
+## BLUEBUTTON-480: Trim Leading and Trailing Whitespace from Codes
+
+Some of our source data erroneously included leading/trailing whitespace, which was being passed through to the `Coding` entries that it ended up being used in.
+
+All `Coding`s returned by the API should now have leading and trailing whitespace trimmed.
+
 ## BLUEBUTTON-239: Remove the HICN Hash from `Patient.identifier`
 
 Previously, EOB responses had included a one-way cryptographic hash of each beneficiary's current HICN.


### PR DESCRIPTION
Looks like https://github.com/CMSgov/bluebutton-data-server/pull/116 was erroneously reported as passing the build: it wasn't. I think it's just a build ordering issue: that build completed before the sample data change that it relied on was merged to `master`.

https://jira.cms.gov/browse/BLUEBUTTON-507