### PR TITLE
BLUEBUTTON-865: Adding plaintext HICN and MBI to patient resource

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
@@ -17,6 +17,7 @@ import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistory;
 import gov.hhs.cms.bluebutton.data.model.rif.MedicareBeneficiaryIdHistory;
 import gov.hhs.cms.bluebutton.data.model.rif.parse.InvalidRifValueException;
+import gov.hhs.cms.bluebutton.server.app.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 
 /**
  * Transforms CCW {@link Beneficiary} instances into FHIR {@link Patient}
@@ -24,32 +25,29 @@ import gov.hhs.cms.bluebutton.data.model.rif.parse.InvalidRifValueException;
  */
 final class BeneficiaryTransformer {
 	/**
-	 * @param metricRegistry
-	 *            the {@link MetricRegistry} to use
-	 * @param beneficiary
-	 *            the CCW {@link Beneficiary} to transform
-	 * @param includeIdentifiers
+	 * @param metricRegistry         the {@link MetricRegistry} to use
+	 * @param beneficiary            the CCW {@link Beneficiary} to transform
+	 * @param includeIdentifiersMode the {@link IncludeIdentifiersMode} to use
 	 * @return a FHIR {@link Patient} resource that represents the specified
 	 *         {@link Beneficiary}
 	 */
 	public static Patient transform(MetricRegistry metricRegistry, Beneficiary beneficiary,
-			Boolean includeIdentifiers) {
+			IncludeIdentifiersMode includeIdentifiersMode) {
 		Timer.Context timer = metricRegistry
 				.timer(MetricRegistry.name(BeneficiaryTransformer.class.getSimpleName(), "transform")).time();
-		Patient patient = transform(beneficiary, includeIdentifiers);
+		Patient patient = transform(beneficiary, includeIdentifiersMode);
 		timer.stop();
 
 		return patient;
 	}
 
 	/**
-	 * @param beneficiary
-	 *            the CCW {@link Beneficiary} to transform
-	 * @param includeIdentifiers
+	 * @param beneficiary            the CCW {@link Beneficiary} to transform
+	 * @param includeIdentifiersMode the {@link IncludeIdentifiersMode} to use
 	 * @return a FHIR {@link Patient} resource that represents the specified
 	 *         {@link Beneficiary}
 	 */
-	private static Patient transform(Beneficiary beneficiary, Boolean includeIdentifiers) {
+	private static Patient transform(Beneficiary beneficiary, IncludeIdentifiersMode includeIdentifiersMode) {
 		Objects.requireNonNull(beneficiary);
 
 		Patient patient = new Patient();
@@ -60,7 +58,7 @@ final class BeneficiaryTransformer {
 		patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH)
 				.setValue(beneficiary.getHicn());
 
-		if (includeIdentifiers) {
+		if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS) {
 			List<String> unhashedHicns = new ArrayList<String>();
 			unhashedHicns.add(beneficiary.getHicnUnhashed().get());
 			for (BeneficiaryHistory beneHistory : beneficiary.getBeneficiaryHistories()) {

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
@@ -29,7 +29,8 @@ final class BeneficiaryTransformer {
 	 * @return a FHIR {@link Patient} resource that represents the specified
 	 *         {@link Beneficiary}
 	 */
-	public static Patient transform(MetricRegistry metricRegistry, Beneficiary beneficiary, String includeIdentifiers) {
+	public static Patient transform(MetricRegistry metricRegistry, Beneficiary beneficiary,
+			Boolean includeIdentifiers) {
 		Timer.Context timer = metricRegistry
 				.timer(MetricRegistry.name(BeneficiaryTransformer.class.getSimpleName(), "transform")).time();
 		Patient patient = transform(beneficiary, includeIdentifiers);
@@ -45,7 +46,7 @@ final class BeneficiaryTransformer {
 	 * @return a FHIR {@link Patient} resource that represents the specified
 	 *         {@link Beneficiary}
 	 */
-	private static Patient transform(Beneficiary beneficiary, String includeIdentifiers) {
+	private static Patient transform(Beneficiary beneficiary, Boolean includeIdentifiers) {
 		Objects.requireNonNull(beneficiary);
 
 		Patient patient = new Patient();
@@ -56,7 +57,7 @@ final class BeneficiaryTransformer {
 		patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH)
 				.setValue(beneficiary.getHicn());
 
-		if (Boolean.parseBoolean(includeIdentifiers) == true) {
+		if (includeIdentifiers) {
 			patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED)
 					.setValue(beneficiary.getHicnUnhashed().get());
 			for (BeneficiaryHistory beneHistory : beneficiary.getBeneficiaryHistories()) {

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
@@ -11,6 +11,8 @@ import com.codahale.metrics.Timer;
 
 import gov.hhs.cms.bluebutton.data.codebook.data.CcwCodebookVariable;
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
+import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistory;
+import gov.hhs.cms.bluebutton.data.model.rif.MedicareBeneficiaryIdHistory;
 import gov.hhs.cms.bluebutton.data.model.rif.parse.InvalidRifValueException;
 
 /**
@@ -51,6 +53,17 @@ final class BeneficiaryTransformer {
 				TransformerUtils.createIdentifier(CcwCodebookVariable.BENE_ID, beneficiary.getBeneficiaryId()));
 		patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH)
 				.setValue(beneficiary.getHicn());
+
+		patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED)
+				.setValue(beneficiary.getHicnUnhashed().get());
+		for (BeneficiaryHistory beneHistory : beneficiary.getBeneficiaryHistories()) {
+			patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED)
+					.setValue(beneHistory.getHicnUnhashed().get());
+		}
+		for (MedicareBeneficiaryIdHistory mbiHistory : beneficiary.getMedicareBeneficiaryIdHistories()) {
+			patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID)
+					.setValue(mbiHistory.getMedicareBeneficiaryId().get());
+		}
 
 		patient.addAddress().setState(beneficiary.getStateCode()).setDistrict(beneficiary.getCountyCode())
 				.setPostalCode(beneficiary.getPostalCode());

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
@@ -1,6 +1,9 @@
 package gov.hhs.cms.bluebutton.server.app.stu3.providers;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender;
 import org.hl7.fhir.dstu3.model.HumanName;
@@ -58,18 +61,26 @@ final class BeneficiaryTransformer {
 				.setValue(beneficiary.getHicn());
 
 		if (includeIdentifiers) {
-			patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED)
-					.setValue(beneficiary.getHicnUnhashed().get());
+			List<String> unhashedHicns = new ArrayList<String>();
+			unhashedHicns.add(beneficiary.getHicnUnhashed().get());
 			for (BeneficiaryHistory beneHistory : beneficiary.getBeneficiaryHistories()) {
+				unhashedHicns.add(beneHistory.getHicnUnhashed().get());
+			}
+			List<String> unhashedHicnsNoDupes = unhashedHicns.stream().distinct().collect(Collectors.toList());
+			for (String hicn : unhashedHicnsNoDupes) {
 				patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED)
-						.setValue(beneHistory.getHicnUnhashed().get());
+						.setValue(hicn);
 			}
 
-			patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED)
-					.setValue(beneficiary.getMedicareBeneficiaryId().get());
+			List<String> unhashedMbis = new ArrayList<String>();
+			unhashedMbis.add(beneficiary.getMedicareBeneficiaryId().get());
 			for (MedicareBeneficiaryIdHistory mbiHistory : beneficiary.getMedicareBeneficiaryIdHistories()) {
+				unhashedMbis.add(mbiHistory.getMedicareBeneficiaryId().get());
+			}
+			List<String> unhashedMbisNoDupes = unhashedMbis.stream().distinct().collect(Collectors.toList());
+			for (String mbi : unhashedMbisNoDupes) {
 				patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED)
-						.setValue(mbiHistory.getMedicareBeneficiaryId().get());
+						.setValue(mbi);
 			}
 		}
 

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProvider.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProvider.java
@@ -134,9 +134,9 @@ public final class PatientResourceProvider implements IResourceProvider {
 			timerBeneQuery.stop();
 		}
 
-		String includeIdentifiers = "false";
+		Boolean includeIdentifiers = false;
 		if ("true".equals(requestDetails.getHeader("IncludeIdentifiers")))
-			includeIdentifiers = "true";
+			includeIdentifiers = true;
 		Patient patient = BeneficiaryTransformer.transform(metricRegistry, beneficiary, includeIdentifiers);
 		return patient;
 	}
@@ -310,9 +310,9 @@ public final class PatientResourceProvider implements IResourceProvider {
 			throw new NoResultException();
 		}
 
-		String includeIdentifiers = "false";
+		Boolean includeIdentifiers = false;
 		if ("true".equals(requestDetails.getHeader("IncludeIdentifiers")))
-			includeIdentifiers = "true";
+			includeIdentifiers = true;
 		Patient patient = BeneficiaryTransformer.transform(metricRegistry, beneficiary, includeIdentifiers);
 		return patient;
 	}

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
@@ -228,13 +228,14 @@ public final class TransformerConstants {
 	 * The {@link Identifier#getSystem()} used in {@link Patient} resources to
 	 * store the unhashed version of each Medicare beneficiaries' HICN.
 	 */
-	public static final String CODING_BBAPI_BENE_HICN_UNHASHED = BASE_URL_BBAPI_RESOURCES + "/identifier/hicn-unhashed";
+	public static final String CODING_BBAPI_BENE_HICN_UNHASHED = "http://hl7.org/fhir/sid/us-medicare";
 
 	/**
 	 * The {@link Identifier#getSystem()} used in {@link Patient} resources to
-	 * store the each Medicare beneficiaries' medicare beneficiary id.
+	 * store the unhashed version of each Medicare beneficiaries' medicare
+	 * beneficiary id.
 	 */
-	public static final String CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED = BASE_URL_BBAPI_RESOURCES + "/identifier/mbi-unhashed";
+	public static final String CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED = "http://hl7.org/fhir/sid/us-mbi";
 
 	/**
 	 * The {@link #CODING_BBAPI_BENE_HICN_HASH} used in earlier versions of the API,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
@@ -154,6 +154,12 @@ public final class TransformerConstants {
 	 * helpful documentation at the URL.)
 	 */
 	static final String CODING_SYSTEM_HCPCS = BASE_URL_BBAPI_RESOURCES + "/codesystem/hcpcs";
+	
+	/**
+	 * Used as the {@link Coding#getSystem()} for determining the currency of an
+	 * {@link Identifier}.
+	 */
+	static final String CODING_SYSTEM_IDENTIFIER_CURRENCY = BASE_URL_BBAPI_RESOURCES + "/codesystem/identifier-currency";
 
 	/**
 	 * The standard {@link Money#getSystem()} for currency. (It looks odd that it

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
@@ -234,7 +234,7 @@ public final class TransformerConstants {
 	 * The {@link Identifier#getSystem()} used in {@link Patient} resources to
 	 * store the each Medicare beneficiaries' medicare beneficiary id.
 	 */
-	public static final String CODING_BBAPI_MEDICARE_BENEFICIARY_ID = BASE_URL_BBAPI_RESOURCES + "/identifier/mbi";
+	public static final String CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED = BASE_URL_BBAPI_RESOURCES + "/identifier/mbi-unhashed";
 
 	/**
 	 * The {@link #CODING_BBAPI_BENE_HICN_HASH} used in earlier versions of the API,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
@@ -223,6 +223,18 @@ public final class TransformerConstants {
 	 * now.
 	 */
 	public static final String CODING_BBAPI_BENE_HICN_HASH = BASE_URL_BBAPI_RESOURCES + "/identifier/hicn-hash";
+	
+	/**
+	 * The {@link Identifier#getSystem()} used in {@link Patient} resources to
+	 * store the unhashed version of each Medicare beneficiaries' HICN.
+	 */
+	public static final String CODING_BBAPI_BENE_HICN_UNHASHED = BASE_URL_BBAPI_RESOURCES + "/identifier/hicn-unhashed";
+
+	/**
+	 * The {@link Identifier#getSystem()} used in {@link Patient} resources to
+	 * store the each Medicare beneficiaries' medicare beneficiary id.
+	 */
+	public static final String CODING_BBAPI_MEDICARE_BENEFICIARY_ID = BASE_URL_BBAPI_RESOURCES + "/identifier/mbi";
 
 	/**
 	 * The {@link #CODING_BBAPI_BENE_HICN_HASH} used in earlier versions of the API,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
@@ -102,6 +102,7 @@ import gov.hhs.cms.bluebutton.data.model.rif.SNFClaim;
 import gov.hhs.cms.bluebutton.data.model.rif.SNFClaimColumn;
 import gov.hhs.cms.bluebutton.data.model.rif.SNFClaimLine;
 import gov.hhs.cms.bluebutton.server.app.FDADrugDataUtilityApp;
+import gov.hhs.cms.bluebutton.server.app.stu3.providers.BeneficiaryTransformer.CurrencyIdentifier;
 import gov.hhs.cms.bluebutton.server.app.stu3.providers.Diagnosis.DiagnosisLabel;
 
 /**
@@ -3038,5 +3039,28 @@ public final class TransformerUtils {
 		b.append("&" + descriptor + "=" + id);
 
 		return b.toString();
+	}
+
+	/**
+	 * @param currencyIdentifier
+	 *            the {@link CurrencyIdentifier} indicating the currency of an
+	 *            {@link Identifier}.
+	 * @return Returns an {@link Extension} describing the currency of an
+	 *         {@link Identifier}.
+	 */
+	public static Extension createIdentifierCurrencyExtension(CurrencyIdentifier currencyIdentifier) {
+		String system = TransformerConstants.CODING_SYSTEM_IDENTIFIER_CURRENCY;
+		String code = "historic";
+		String display = "Historic";
+		if (currencyIdentifier.equals(CurrencyIdentifier.CURRENT)) {
+			code = "current";
+			display = "Current";
+		}
+
+		Coding currentValueCoding = new Coding(system, code, display);
+		Extension currencyIdentifierExtension = new Extension(TransformerConstants.CODING_SYSTEM_IDENTIFIER_CURRENCY,
+				currentValueCoding);
+
+		return currencyIdentifierExtension;
 	}
 }

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformerTest.java
@@ -34,7 +34,7 @@ public final class BeneficiaryTransformerTest {
 		Beneficiary beneficiary = parsedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
 				.findFirst().get();
 
-		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary);
+		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, "false");
 		assertMatches(beneficiary, patient);
 	}
 
@@ -51,7 +51,7 @@ public final class BeneficiaryTransformerTest {
 				.findFirst().get();
 		TransformerTestUtils.setAllOptionalsToEmpty(beneficiary);
 
-		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary);
+		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, "false");
 		assertMatches(beneficiary, patient);
 	}
 

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformerTest.java
@@ -4,6 +4,8 @@ import java.sql.Date;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender;
 import org.hl7.fhir.dstu3.model.Patient;
@@ -14,9 +16,12 @@ import com.codahale.metrics.MetricRegistry;
 
 import gov.hhs.cms.bluebutton.data.codebook.data.CcwCodebookVariable;
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
+import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistory;
+import gov.hhs.cms.bluebutton.data.model.rif.MedicareBeneficiaryIdHistory;
 import gov.hhs.cms.bluebutton.data.model.rif.samples.StaticRifResource;
 import gov.hhs.cms.bluebutton.data.model.rif.samples.StaticRifResourceGroup;
 import gov.hhs.cms.bluebutton.server.app.ServerTestUtils;
+import gov.hhs.cms.bluebutton.server.app.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 
 /**
  * Unit tests for {@link BeneficiaryTransformer}.
@@ -29,13 +34,64 @@ public final class BeneficiaryTransformerTest {
 	 */
 	@Test
 	public void transformSampleARecord() {
+		Beneficiary beneficiary = loadSampleABeneficiary();
+
+		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary,
+				IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+		assertMatches(beneficiary, patient);
+		Assert.assertEquals(2, patient.getIdentifier().size());
+	}
+
+	/**
+	 * Verifies that {@link BeneficiaryTransformer#transform(Beneficiary)} works as
+	 * expected when run against the {@link StaticRifResource#SAMPLE_A_BENES}
+	 * {@link Beneficiary}, in the
+	 * {@link IncludeIdentifiersMode#INCLUDE_HICNS_AND_MBIS} mode.
+	 */
+	@Test
+	public void transformSampleARecordWithIdentifiers() {
+		Beneficiary beneficiary = loadSampleABeneficiary();
+
+		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary,
+				IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+		assertMatches(beneficiary, patient);
+		Assert.assertEquals(7, patient.getIdentifier().size());
+	}
+
+	/**
+	 * @return the {@link StaticRifResourceGroup#SAMPLE_A} {@link Beneficiary}
+	 *         record, with the {@link Beneficiary#getBeneficiaryHistories()} and
+	 *         {@link Beneficiary#getMedicareBeneficiaryIdHistories()} fields
+	 *         populated.
+	 */
+	private static Beneficiary loadSampleABeneficiary() {
 		List<Object> parsedRecords = ServerTestUtils
 				.parseData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+
+		// Pull out the base Beneficiary record and fix its HICN fields.
 		Beneficiary beneficiary = parsedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
 				.findFirst().get();
+		beneficiary.setHicnUnhashed(Optional.of(beneficiary.getHicn()));
+		beneficiary.setHicn("somehash");
 
-		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, false);
-		assertMatches(beneficiary, patient);
+		// Add the HICN history records to the Beneficiary, and fix their HICN fields.
+		Set<BeneficiaryHistory> beneficiaryHistories = parsedRecords.stream()
+				.filter(r -> r instanceof BeneficiaryHistory).map(r -> (BeneficiaryHistory) r)
+				.filter(r -> beneficiary.getBeneficiaryId().equals(r.getBeneficiaryId())).collect(Collectors.toSet());
+		beneficiary.getBeneficiaryHistories().addAll(beneficiaryHistories);
+		for (BeneficiaryHistory beneficiaryHistory : beneficiary.getBeneficiaryHistories()) {
+			beneficiaryHistory.setHicnUnhashed(Optional.of(beneficiaryHistory.getHicn()));
+			beneficiaryHistory.setHicn("somehash");
+		}
+
+		// Add the MBI history records to the Beneficiary.
+		Set<MedicareBeneficiaryIdHistory> beneficiaryMbis = parsedRecords.stream()
+				.filter(r -> r instanceof MedicareBeneficiaryIdHistory).map(r -> (MedicareBeneficiaryIdHistory) r)
+				.filter(r -> beneficiary.getBeneficiaryId().equals(r.getBeneficiaryId().orElse(null)))
+				.collect(Collectors.toSet());
+		beneficiary.getMedicareBeneficiaryIdHistories().addAll(beneficiaryMbis);
+
+		return beneficiary;
 	}
 
 	/**
@@ -51,7 +107,8 @@ public final class BeneficiaryTransformerTest {
 				.findFirst().get();
 		TransformerTestUtils.setAllOptionalsToEmpty(beneficiary);
 
-		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, false);
+		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary,
+				IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
 		assertMatches(beneficiary, patient);
 	}
 

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformerTest.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformerTest.java
@@ -34,7 +34,7 @@ public final class BeneficiaryTransformerTest {
 		Beneficiary beneficiary = parsedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
 				.findFirst().get();
 
-		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, "false");
+		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, false);
 		assertMatches(beneficiary, patient);
 	}
 
@@ -51,7 +51,7 @@ public final class BeneficiaryTransformerTest {
 				.findFirst().get();
 		TransformerTestUtils.setAllOptionalsToEmpty(beneficiary);
 
-		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, "false");
+		Patient patient = BeneficiaryTransformer.transform(new MetricRegistry(), beneficiary, false);
 		assertMatches(beneficiary, patient);
 	}
 

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExtraParamsInterceptor.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExtraParamsInterceptor.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.client.api.IClientInterceptor;
 import ca.uhn.fhir.rest.client.api.IHttpRequest;
 import ca.uhn.fhir.rest.client.api.IHttpResponse;
+import gov.hhs.cms.bluebutton.server.app.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 
 /**
  * An interceptor class to add headers to requests for supplying additional
@@ -15,11 +16,12 @@ import ca.uhn.fhir.rest.client.api.IHttpResponse;
  */
 public class ExtraParamsInterceptor implements IClientInterceptor {
 
-	private String includeIdentifiers = "false";
+	private IncludeIdentifiersMode includeIdentifiersMode = IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS;
 
 	@Override
 	public void interceptRequest(IHttpRequest theRequest) {
-		theRequest.addHeader("IncludeIdentifiers", this.includeIdentifiers);
+		if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS)
+			theRequest.addHeader(IncludeIdentifiersMode.HEADER_NAME_INCLUDE_IDENTIFIERS, Boolean.TRUE.toString());
 	}
 
 	@Override
@@ -28,8 +30,7 @@ public class ExtraParamsInterceptor implements IClientInterceptor {
 
 	}
 
-	public void setIncludeIdentifiers(String includeIdentifiers) {
-		this.includeIdentifiers = includeIdentifiers;
+	public void setIncludeIdentifiers(IncludeIdentifiersMode includeIdentifiersMode) {
+		this.includeIdentifiersMode = includeIdentifiersMode;
 	}
-
 }

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExtraParamsInterceptor.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExtraParamsInterceptor.java
@@ -2,10 +2,17 @@ package gov.hhs.cms.bluebutton.server.app.stu3.providers;
 
 import java.io.IOException;
 
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.client.api.IClientInterceptor;
 import ca.uhn.fhir.rest.client.api.IHttpRequest;
 import ca.uhn.fhir.rest.client.api.IHttpResponse;
 
+/**
+ * An interceptor class to add headers to requests for supplying additional
+ * parameters to FHIR "read" operations. The operation only allows for certain
+ * parameters to be sent (e.g. {@link RequestDetails}) so we add headers with
+ * our own parameters to the request in order to make use of them.
+ */
 public class ExtraParamsInterceptor implements IClientInterceptor {
 
 	private String includeIdentifiers = "false";

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExtraParamsInterceptor.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExtraParamsInterceptor.java
@@ -1,0 +1,28 @@
+package gov.hhs.cms.bluebutton.server.app.stu3.providers;
+
+import java.io.IOException;
+
+import ca.uhn.fhir.rest.client.api.IClientInterceptor;
+import ca.uhn.fhir.rest.client.api.IHttpRequest;
+import ca.uhn.fhir.rest.client.api.IHttpResponse;
+
+public class ExtraParamsInterceptor implements IClientInterceptor {
+
+	private String includeIdentifiers = "false";
+
+	@Override
+	public void interceptRequest(IHttpRequest theRequest) {
+		theRequest.addHeader("IncludeIdentifiers", this.includeIdentifiers);
+	}
+
+	@Override
+	public void interceptResponse(IHttpResponse theResponse) throws IOException {
+		// TODO Auto-generated method stub
+
+	}
+
+	public void setIncludeIdentifiers(String includeIdentifiers) {
+		this.includeIdentifiers = includeIdentifiers;
+	}
+
+}

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProviderIT.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProviderIT.java
@@ -18,6 +18,7 @@ import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistory;
 import gov.hhs.cms.bluebutton.data.model.rif.samples.StaticRifResourceGroup;
 import gov.hhs.cms.bluebutton.server.app.ServerTestUtils;
+import gov.hhs.cms.bluebutton.server.app.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 
 /**
  * Integration tests for {@link PatientResourceProvider}.
@@ -53,7 +54,7 @@ public final class PatientResourceProviderIT {
 				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
 		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
 		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-		extraParamsInterceptor.setIncludeIdentifiers("true");
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
 		fhirClient.registerInterceptor(extraParamsInterceptor);
 
 		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
@@ -92,7 +93,7 @@ public final class PatientResourceProviderIT {
 				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
 		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
 		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-		extraParamsInterceptor.setIncludeIdentifiers("false");
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
 		fhirClient.registerInterceptor(extraParamsInterceptor);
 
 		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
@@ -177,7 +178,7 @@ public final class PatientResourceProviderIT {
 				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
 		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
 		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-		extraParamsInterceptor.setIncludeIdentifiers("true");
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
 		fhirClient.registerInterceptor(extraParamsInterceptor);
 
 		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
@@ -219,7 +220,7 @@ public final class PatientResourceProviderIT {
 				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
 		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
 		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-		extraParamsInterceptor.setIncludeIdentifiers("false");
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
 		fhirClient.registerInterceptor(extraParamsInterceptor);
 
 		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
@@ -342,7 +343,7 @@ public final class PatientResourceProviderIT {
 				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
 		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
 		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-		extraParamsInterceptor.setIncludeIdentifiers("true");
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
 		fhirClient.registerInterceptor(extraParamsInterceptor);
 
 		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
@@ -385,7 +386,7 @@ public final class PatientResourceProviderIT {
 				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
 		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
 		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
-		extraParamsInterceptor.setIncludeIdentifiers("false");
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
 		fhirClient.registerInterceptor(extraParamsInterceptor);
 
 		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)

--- a/bluebutton-server-app/src/test/resources/endpoint-responses/metadata.json
+++ b/bluebutton-server-app/src/test/resources/endpoint-responses/metadata.json
@@ -83,12 +83,6 @@
         "type" : "token",
         "documentation" : "A patient identifier"
       }, {
-        "name" : "includeIdentifiers",
-        "type" : "string"
-      }, {
-        "name" : "includeIdentifiers",
-        "type" : "string"
-      }, {
         "name" : "startIndex",
         "type" : "string"
       }, {

--- a/bluebutton-server-app/src/test/resources/endpoint-responses/metadata.json
+++ b/bluebutton-server-app/src/test/resources/endpoint-responses/metadata.json
@@ -82,6 +82,12 @@
         "type" : "token",
         "documentation" : "A patient identifier"
       }, {
+        "name" : "includeIdentifiers",
+        "type" : "string"
+      }, {
+        "name" : "includeIdentifiers",
+        "type" : "string"
+      }, {
         "name" : "startIndex",
         "type" : "string"
       }, {

--- a/dev/api-changelog.md
+++ b/dev/api-changelog.md
@@ -1,5 +1,38 @@
 # API Changelog
 
+## BLUEBUTTON-865: Adding plaintext HICN/MBI to Patient resource
+
+The Patient resource will now return plaintext HICN/MBI (both current and historical) values when a BCDA-only header (IncludeIdentifiers) is included in the request. The added fields will look like:
+
+	'''{
+      "extension": [
+        {
+          "url": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding": {
+            "system": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code": "current",
+            "display": "Current"
+          }
+        }
+      ],
+      "system": "http://hl7.org/fhir/sid/us-medicare",
+      "value": "543217066U"
+    },
+    {
+      "extension": [
+        {
+          "url": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding": {
+            "system": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code": "current",
+            "display": "Current"
+          }
+        }
+      ],
+      "system": "http://hl7.org/fhir/sid/us-mbi",
+      "value": "3456789"
+    }```
+
 ## BLUEBUTTON-898: Correct `Patient.gender` codings
 
 Fixed the `Patient.gender` codings to be correct. Previously, all beneficiaries had reported a value of `unknown` in this field.


### PR DESCRIPTION
Adding two additional identifiers to the patient resource when querying
for BCDA users (includeIdentifiers=true).

BLUEBUTTON-865