### PR TITLE
BLUEBUTTON-945: Log client SSL principals in access.log

### DIFF
--- a/bluebutton-server-app/src/main/config/server-start.sh
+++ b/bluebutton-server-app/src/main/config/server-start.sh
@@ -123,6 +123,7 @@ serverPortsFile="${workDirectory}/server-ports.properties"
 warArtifact="${targetDirectory}/$(ls ${targetDirectory} | grep '^bluebutton-server-app-.*\.war$')"
 keyStore="${scriptDirectory}/../../../../dev/ssl-stores/server-keystore.jks"
 trustStore="${scriptDirectory}/../../../../dev/ssl-stores/server-truststore.jks"
+rolesProps="${scriptDirectory}/../../../../dev/ssl-stores/server-roles.properties"
 serverHome="${workDirectory}/${serverInstall}"
 serverLog="${workDirectory}/server-console.log"
 
@@ -208,6 +209,9 @@ JAVA_OPTS="\$JAVA_OPTS ${visualVmArgs}"
 # for a debugger to connect when first launching the server.
 #JAVA_OPTS="\$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y"
 
+# Uncomment this next line to enable SSL debug logging. Watch out: it's super noisy.
+#JAVA_OPTS="\$JAVA_OPTS -Djavax.net.debug=all"
+
 # These ports are only used until the server is configured, but need to be
 # set anyways, as the defaults on first launch conflict with Jenkins and other 
 # such services.
@@ -215,7 +219,7 @@ JAVA_OPTS="\$JAVA_OPTS -Djboss.management.http.port=${serverPortManagement} -Djb
 
 # These properties are all referenced within the standalone.xml we'll be using.
 JAVA_OPTS="\$JAVA_OPTS -Dbbfhir.db.url=${dbUrl}"
-JAVA_OPTS="\$JAVA_OPTS -Dbbfhir.ssl.keystore.path=${keyStore} -Dbbfhir.ssl.truststore.path=${trustStore}"
+JAVA_OPTS="\$JAVA_OPTS -Dbbfhir.ssl.keystore.path=${keyStore} -Dbbfhir.ssl.truststore.path=${trustStore} -Dbbfhir.roles=${rolesProps}"
 
 # Used in src/main/resources/logback.xml as the directory to write the app log to. Must have a trailing slash.
 JAVA_OPTS="\$JAVA_OPTS -Dbbfhir.logs.dir=${workDirectory}/"

--- a/bluebutton-server-app/src/main/config/standalone.xml
+++ b/bluebutton-server-app/src/main/config/standalone.xml
@@ -326,6 +326,24 @@
                         <policy-module code="Delegating" flag="required"/>
                     </authorization>
                 </security-domain>
+                <security-domain name="bluebutton-data-server" cache-type="default">
+                    <!-- This is the security realm that the Blue Button Data Server will be
+                        hardcoded to use for its client authentication, in its jboss-web.xml file. -->
+                    <authentication>
+                        <login-module code="CertificateRoles" flag="required">
+                            <module-option name="securityDomain" value="bluebutton-data-server" />
+                            <module-option name="verifier" value="org.jboss.security.auth.certs.AnyCertVerifier"/>
+                            <module-option name="rolesProperties" value="file:${bbfhir.roles}" />
+                        </login-module>
+                    </authentication>
+                    <jsse
+                        keystore-password="${bbfhir.ssl.keystore.storepassword:changeit}"
+                        keystore-url="file:${bbfhir.ssl.keystore.path}"
+                        truststore-password="${bbfhir.ssl.truststore.storepassword:changeit}"
+                        truststore-url="file:${bbfhir.ssl.truststore.path}"
+                        client-auth="true"
+                    />
+                </security-domain>
             </security-domains>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:transactions:2.0">

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/LoggingContextFilter.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/LoggingContextFilter.java
@@ -76,6 +76,10 @@ public final class LoggingContextFilter implements Filter {
 	 *         <code>null</code> if that's not available
 	 */
 	private static String getClientSslPrincipalDistinguishedName(HttpServletRequest request) {
+		/*
+		 * Note: Now that Wildfly/JBoss is properly configured with a security realm,
+		 * this method is equivalent to calling `request.getRemoteUser()`.
+		 */
 		X509Certificate clientCert = getClientCertificate(request);
 		if (clientCert == null || clientCert.getSubjectX500Principal() == null) {
 			LOGGER.debug("No client SSL principal available: {}", clientCert);

--- a/bluebutton-server-app/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/bluebutton-server-app/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-web>
+
+	<!-- The name of the <security-realm /> (from the JBoss/Wildfly standalone.xml
+		configuration file) that this application should use for its authentication. -->
+	<security-domain>bluebutton-data-server</security-domain>
+
+</jboss-web>

--- a/bluebutton-server-app/src/main/webapp/WEB-INF/web.xml
+++ b/bluebutton-server-app/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,11 @@
 <web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	version="3.0" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee ./xsd/web-app_3_0.xsd">
 
+	<login-config>
+		<auth-method>CLIENT-CERT</auth-method>
+		<realm-name>bluebutton-data-server</realm-name>
+	</login-config>
+
 	<!-- Adds some additional context variables that can be included in the 
 		app's logging. -->
 	<filter>

--- a/dev/ssl-stores/server-roles.properties
+++ b/dev/ssl-stores/server-roles.properties
@@ -1,0 +1,2 @@
+# We don't yet have or use roles, but this file is still required by the
+# Wildfly/JBoss `<security-domain name="bluebutton-data-server" />`.


### PR DESCRIPTION
Main change here is the addition of the `<security-domain name="bluebutton-data-server" />` configuration entry, and the `jboss-web.xml` file that activates/selects it for this app. Most everything else just supports that switch.

How does this result in client SSL principals being logged? It makes the "`%r`" variable in our access log pattern (in `standalone.xml`) actually work. With the security domain configured this way, to read the client certificate, the remote use is available and captured in our access logs, e.g. (note the "`CN=client-local-dev`"):

    127.0.0.1 - CN=client-local-dev 29/Jun/2019:21:56:38 -0400 "GET /v1/fhir/metadata HTTP/1.1" "?-" 200 -1 2 - - [-] - "-" - "-" - "-" -

Note the companion PR for `ansible-role-bluebutton-data-server` that has already been merged and deployed. It adds the security domain to our AWS environments' configs.

https://github.com/CMSgov/ansible-role-bluebutton-data-server/pull/7

https://jira.cms.gov/browse/BLUEBUTTON-844