### PR TITLE
BLUEBUTTON-865: return plaintext HICNs and MBIs for BCDA (Round 2)

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/BeneficiaryTransformer.java
@@ -1,9 +1,14 @@
 package gov.hhs.cms.bluebutton.server.app.stu3.providers;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender;
+import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.HumanName;
+import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Patient;
 
 import com.codahale.metrics.MetricRegistry;
@@ -11,6 +16,10 @@ import com.codahale.metrics.Timer;
 
 import gov.hhs.cms.bluebutton.data.codebook.data.CcwCodebookVariable;
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
+import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistory;
+import gov.hhs.cms.bluebutton.data.model.rif.MedicareBeneficiaryIdHistory;
+import gov.hhs.cms.bluebutton.data.model.rif.parse.InvalidRifValueException;
+import gov.hhs.cms.bluebutton.server.app.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 
 /**
  * Transforms CCW {@link Beneficiary} instances into FHIR {@link Patient}
@@ -18,29 +27,29 @@ import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
  */
 final class BeneficiaryTransformer {
 	/**
-	 * @param metricRegistry
-	 *            the {@link MetricRegistry} to use
-	 * @param beneficiary
-	 *            the CCW {@link Beneficiary} to transform
+	 * @param metricRegistry         the {@link MetricRegistry} to use
+	 * @param beneficiary            the CCW {@link Beneficiary} to transform
+	 * @param includeIdentifiersMode the {@link IncludeIdentifiersMode} to use
 	 * @return a FHIR {@link Patient} resource that represents the specified
 	 *         {@link Beneficiary}
 	 */
-	public static Patient transform(MetricRegistry metricRegistry, Beneficiary beneficiary) {
+	public static Patient transform(MetricRegistry metricRegistry, Beneficiary beneficiary,
+			IncludeIdentifiersMode includeIdentifiersMode) {
 		Timer.Context timer = metricRegistry
 				.timer(MetricRegistry.name(BeneficiaryTransformer.class.getSimpleName(), "transform")).time();
-		Patient patient = transform(beneficiary);
+		Patient patient = transform(beneficiary, includeIdentifiersMode);
 		timer.stop();
 
 		return patient;
 	}
 
 	/**
-	 * @param beneficiary
-	 *            the CCW {@link Beneficiary} to transform
+	 * @param beneficiary            the CCW {@link Beneficiary} to transform
+	 * @param includeIdentifiersMode the {@link IncludeIdentifiersMode} to use
 	 * @return a FHIR {@link Patient} resource that represents the specified
 	 *         {@link Beneficiary}
 	 */
-	private static Patient transform(Beneficiary beneficiary) {
+	private static Patient transform(Beneficiary beneficiary, IncludeIdentifiersMode includeIdentifiersMode) {
 		Objects.requireNonNull(beneficiary);
 
 		Patient patient = new Patient();
@@ -50,6 +59,40 @@ final class BeneficiaryTransformer {
 				TransformerUtils.createIdentifier(CcwCodebookVariable.BENE_ID, beneficiary.getBeneficiaryId()));
 		patient.addIdentifier().setSystem(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH)
 				.setValue(beneficiary.getHicn());
+
+		if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS) {
+			Extension currentIdentifier = TransformerUtils
+					.createIdentifierCurrencyExtension(CurrencyIdentifier.CURRENT);
+			
+			addUnhashedIdentifier(patient, beneficiary.getHicnUnhashed().get(),
+					TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED, currentIdentifier);
+
+			addUnhashedIdentifier(patient, beneficiary.getMedicareBeneficiaryId().get(),
+					TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED, currentIdentifier);
+
+			Extension historicalIdentifier = TransformerUtils
+					.createIdentifierCurrencyExtension(CurrencyIdentifier.HISTORIC);
+
+			List<String> unhashedHicns = new ArrayList<String>();
+			for (BeneficiaryHistory beneHistory : beneficiary.getBeneficiaryHistories()) {
+				unhashedHicns.add(beneHistory.getHicnUnhashed().get());
+			}
+			List<String> unhashedHicnsNoDupes = unhashedHicns.stream().distinct().collect(Collectors.toList());
+			for (String hicn : unhashedHicnsNoDupes) {
+				addUnhashedIdentifier(patient, hicn, TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED,
+						historicalIdentifier);
+			}
+
+			List<String> unhashedMbis = new ArrayList<String>();
+			for (MedicareBeneficiaryIdHistory mbiHistory : beneficiary.getMedicareBeneficiaryIdHistories()) {
+				unhashedMbis.add(mbiHistory.getMedicareBeneficiaryId().get());
+			}
+			List<String> unhashedMbisNoDupes = unhashedMbis.stream().distinct().collect(Collectors.toList());
+			for (String mbi : unhashedMbisNoDupes) {
+				addUnhashedIdentifier(patient, mbi, TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED,
+						historicalIdentifier);
+			}
+		}
 
 		patient.addAddress().setState(beneficiary.getStateCode()).setDistrict(beneficiary.getCountyCode())
 				.setPostalCode(beneficiary.getPostalCode());
@@ -133,5 +176,29 @@ final class BeneficiaryTransformer {
 		}
 
 		return patient;
+	}
+
+	/**
+	 * @param patient
+	 *            the FHIR {@link Patient} resource to add the {@link Identifier} to
+	 * @param value
+	 *            the value for {@link Identifier#getValue()}
+	 * @param system
+	 *            the value for {@link Identifier#getSystem()}
+	 * @param identifierCurrencyExtension
+	 *            the {@link Extension} to add to the {@link Identifier}
+	 */
+	private static void addUnhashedIdentifier(Patient patient, String value, String system,
+			Extension identifierCurrencyExtension) {
+		patient.addIdentifier().setSystem(system).setValue(value).addExtension(identifierCurrencyExtension);
+	}
+
+	/**
+	 * Enumerates the options for the currency of an {@link Identifier}.
+	 */
+	public static enum CurrencyIdentifier {
+		CURRENT,
+
+		HISTORIC;
 	}
 }

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProvider.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProvider.java
@@ -103,7 +103,7 @@ public final class PatientResourceProvider implements IResourceProvider {
 	 *         <code>null</code> if none exists.
 	 */
 	@Read(version = false)
-	public Patient read(@IdParam IdType patientId) {
+	public Patient read(@IdParam IdType patientId, RequestDetails requestDetails) {
 		if (patientId == null)
 			throw new IllegalArgumentException();
 		if (patientId.getVersionIdPartAsLong() != null)
@@ -113,12 +113,21 @@ public final class PatientResourceProvider implements IResourceProvider {
 		if (beneIdText == null || beneIdText.trim().isEmpty())
 			throw new IllegalArgumentException();
 
-		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
-
 		Timer.Context timerBeneQuery = metricRegistry
 				.timer(MetricRegistry.name(getClass().getSimpleName(), "query", "bene_by_id")).time();
+
+		IncludeIdentifiersMode includeIdentifiersMode = IncludeIdentifiersMode
+				.determineIncludeIdentifiersMode(requestDetails);
+
+		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
 		CriteriaQuery<Beneficiary> criteria = builder.createQuery(Beneficiary.class);
 		Root<Beneficiary> root = criteria.from(Beneficiary.class);
+		if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS) {
+			// For efficiency, grab these relations in the same query.
+			// For security, only grab them when needed.
+			root.fetch(Beneficiary_.beneficiaryHistories);
+			root.fetch(Beneficiary_.medicareBeneficiaryIdHistories);
+		}
 		criteria.select(root);
 		criteria.where(builder.equal(root.get(Beneficiary_.beneficiaryId), beneIdText));
 
@@ -131,7 +140,7 @@ public final class PatientResourceProvider implements IResourceProvider {
 			timerBeneQuery.stop();
 		}
 
-		Patient patient = BeneficiaryTransformer.transform(metricRegistry, beneficiary);
+		Patient patient = BeneficiaryTransformer.transform(metricRegistry, beneficiary, includeIdentifiersMode);
 		return patient;
 	}
 
@@ -171,7 +180,7 @@ public final class PatientResourceProvider implements IResourceProvider {
 
 		List<IBaseResource> patients;
 		try {
-			patients = Arrays.asList(read(new IdType(logicalId.getValue())));
+			patients = Arrays.asList(read(new IdType(logicalId.getValue()), requestDetails));
 		} catch (ResourceNotFoundException e) {
 			patients = new LinkedList<>();
 		}
@@ -227,7 +236,7 @@ public final class PatientResourceProvider implements IResourceProvider {
 
 		List<IBaseResource> patients;
 		try {
-			patients = Arrays.asList(queryDatabaseByHicnHash(identifier.getValue()));
+			patients = Arrays.asList(queryDatabaseByHicnHash(identifier.getValue(), requestDetails));
 		} catch (NoResultException e) {
 			patients = new LinkedList<>();
 		}
@@ -247,7 +256,7 @@ public final class PatientResourceProvider implements IResourceProvider {
 	 *             A {@link NoResultException} will be thrown if no matching
 	 *             {@link Beneficiary} can be found
 	 */
-	private Patient queryDatabaseByHicnHash(String hicnHash) {
+	private Patient queryDatabaseByHicnHash(String hicnHash, RequestDetails requestDetails) {
 		if (hicnHash == null || hicnHash.trim().isEmpty())
 			throw new IllegalArgumentException();
 
@@ -266,6 +275,8 @@ public final class PatientResourceProvider implements IResourceProvider {
 				.timer(MetricRegistry.name(getClass().getSimpleName(), "query", "bene_by_hicn", "current")).time();
 		CriteriaQuery<String> beneHicnQuery = builder.createQuery(String.class);
 		Root<Beneficiary> beneHicnQueryRoot = beneHicnQuery.from(Beneficiary.class);
+		beneHicnQueryRoot.join(Beneficiary_.beneficiaryHistories);
+		beneHicnQueryRoot.join(Beneficiary_.medicareBeneficiaryIdHistories);
 		beneHicnQuery.select(beneHicnQueryRoot.get(Beneficiary_.beneficiaryId));
 		beneHicnQuery.where(builder.equal(beneHicnQueryRoot.get(Beneficiary_.hicn), hicnHash));
 		matchingBeneficiaryIds.addAll(entityManager.createQuery(beneHicnQuery).getResultList());
@@ -297,12 +308,53 @@ public final class PatientResourceProvider implements IResourceProvider {
 		 * table, we watch out for cases where a matching Beneficiary can't be found
 		 * (again: data is always dirty).
 		 */
-		Beneficiary beneficiary = entityManager.find(Beneficiary.class, matchingBeneficiaryIds.iterator().next());
-		if (beneficiary == null) {
-			throw new NoResultException();
+		String beneIdText = matchingBeneficiaryIds.iterator().next();
+		IncludeIdentifiersMode includeIdentifiersMode = IncludeIdentifiersMode
+				.determineIncludeIdentifiersMode(requestDetails);
+		CriteriaQuery<Beneficiary> criteria = builder.createQuery(Beneficiary.class);
+		Root<Beneficiary> root = criteria.from(Beneficiary.class);
+		if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS) {
+			// For efficiency, grab these relations in the same query.
+			// For security, only grab them when needed.
+			root.fetch(Beneficiary_.beneficiaryHistories);
+			root.fetch(Beneficiary_.medicareBeneficiaryIdHistories);
+		}
+		criteria.select(root);
+		criteria.where(builder.equal(root.get(Beneficiary_.beneficiaryId), beneIdText));
+		Beneficiary beneficiary = null;
+		try {
+			beneficiary = entityManager.createQuery(criteria).getSingleResult();
+		} catch (NoResultException e) {
+			throw new ResourceNotFoundException(beneIdText);
 		}
 
-		Patient patient = BeneficiaryTransformer.transform(metricRegistry, beneficiary);
+		Patient patient = BeneficiaryTransformer.transform(metricRegistry, beneficiary, includeIdentifiersMode);
 		return patient;
+	}
+
+	/**
+	 * Enumerates the supported "should we include unique beneficiary identifiers"
+	 * options.
+	 */
+	public static enum IncludeIdentifiersMode {
+		INCLUDE_HICNS_AND_MBIS,
+
+		OMIT_HICNS_AND_MBIS;
+
+		/**
+		 * The header key used to determine which {@link IncludeIdentifiersMode} mode should
+		 * be used. See {@link #determineIncludeIdentifiersMode(RequestDetails)} for
+		 * details.
+		 */
+		public static final String HEADER_NAME_INCLUDE_IDENTIFIERS = "IncludeIdentifiers";
+
+		static IncludeIdentifiersMode determineIncludeIdentifiersMode(RequestDetails requestDetails) {
+			String includeIdentifiersValue = requestDetails.getHeader(HEADER_NAME_INCLUDE_IDENTIFIERS);
+			if (Boolean.parseBoolean(includeIdentifiersValue) == true) {
+				return INCLUDE_HICNS_AND_MBIS;
+			} else {
+				return OMIT_HICNS_AND_MBIS;
+			}
+		}
 	}
 }

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProvider.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProvider.java
@@ -12,6 +12,7 @@ import javax.persistence.NonUniqueResultException;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.SetJoin;
@@ -279,8 +280,8 @@ public final class PatientResourceProvider implements IResourceProvider {
 		 * SELECT
 		 *     *   -- Retrieved columns are dynamic, based on JPA fetch groups and IncludeIdentifiers.
 		 *   FROM "Beneficiaries"
-		 *   INNER JOIN "BeneficiariesHistory" ON "Beneficiaries"."beneficiaryId" = "BeneficiariesHistory"."beneficiaryId"
-		 *   INNER JOIN "MedicareBeneficiaryIdHistory" ON "Beneficiaries"."beneficiaryId" = "MedicareBeneficiaryIdHistory"."beneficiaryId"  -- Might be omitted, if JPA is smart enough.
+		 *   LEFT JOIN "BeneficiariesHistory" ON "Beneficiaries"."beneficiaryId" = "BeneficiariesHistory"."beneficiaryId"
+		 *   LEFT JOIN "MedicareBeneficiaryIdHistory" ON "Beneficiaries"."beneficiaryId" = "MedicareBeneficiaryIdHistory"."beneficiaryId"  -- Might be omitted, if JPA is smart enough.
 		 *   WHERE
 		 *     "Beneficiaries"."hicn" = $1
 		 *     OR "BeneficiariesHistory"."hicn" = $1
@@ -298,7 +299,8 @@ public final class PatientResourceProvider implements IResourceProvider {
 		CriteriaBuilder builder = entityManager.getCriteriaBuilder();
 		CriteriaQuery<Beneficiary> criteria = builder.createQuery(Beneficiary.class);
 		Root<Beneficiary> rootBenes = criteria.from(Beneficiary.class);
-		SetJoin<Beneficiary, BeneficiaryHistory> joinHistory = rootBenes.join(Beneficiary_.beneficiaryHistories);
+		SetJoin<Beneficiary, BeneficiaryHistory> joinHistory = rootBenes.join(Beneficiary_.beneficiaryHistories,
+				JoinType.LEFT);
 		if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS) {
 			// For efficiency, grab these relations in the same query.
 			// For security, only grab them when needed.

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerConstants.java
@@ -154,6 +154,12 @@ public final class TransformerConstants {
 	 * helpful documentation at the URL.)
 	 */
 	static final String CODING_SYSTEM_HCPCS = BASE_URL_BBAPI_RESOURCES + "/codesystem/hcpcs";
+	
+	/**
+	 * Used as the {@link Coding#getSystem()} for determining the currency of an
+	 * {@link Identifier}.
+	 */
+	static final String CODING_SYSTEM_IDENTIFIER_CURRENCY = BASE_URL_BBAPI_RESOURCES + "/codesystem/identifier-currency";
 
 	/**
 	 * The standard {@link Money#getSystem()} for currency. (It looks odd that it
@@ -229,6 +235,19 @@ public final class TransformerConstants {
 	 * now.
 	 */
 	public static final String CODING_BBAPI_BENE_HICN_HASH = BASE_URL_BBAPI_RESOURCES + "/identifier/hicn-hash";
+	
+	/**
+	 * The {@link Identifier#getSystem()} used in {@link Patient} resources to
+	 * store the unhashed version of each Medicare beneficiaries' HICN.
+	 */
+	public static final String CODING_BBAPI_BENE_HICN_UNHASHED = "http://hl7.org/fhir/sid/us-medicare";
+
+	/**
+	 * The {@link Identifier#getSystem()} used in {@link Patient} resources to
+	 * store the unhashed version of each Medicare beneficiaries' medicare
+	 * beneficiary id.
+	 */
+	public static final String CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED = "http://hl7.org/fhir/sid/us-mbi";
 
 	/**
 	 * The {@link #CODING_BBAPI_BENE_HICN_HASH} used in earlier versions of the API,

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/TransformerUtils.java
@@ -105,6 +105,7 @@ import gov.hhs.cms.bluebutton.data.model.rif.SNFClaimColumn;
 import gov.hhs.cms.bluebutton.data.model.rif.SNFClaimLine;
 import gov.hhs.cms.bluebutton.data.model.rif.parse.InvalidRifValueException;
 import gov.hhs.cms.bluebutton.server.app.FDADrugDataUtilityApp;
+import gov.hhs.cms.bluebutton.server.app.stu3.providers.BeneficiaryTransformer.CurrencyIdentifier;
 import gov.hhs.cms.bluebutton.server.app.stu3.providers.Diagnosis.DiagnosisLabel;
 
 /**
@@ -3075,5 +3076,28 @@ public final class TransformerUtils {
 		b.append("&" + descriptor + "=" + id);
 
 		return b.toString();
+	}
+
+	/**
+	 * @param currencyIdentifier
+	 *            the {@link CurrencyIdentifier} indicating the currency of an
+	 *            {@link Identifier}.
+	 * @return Returns an {@link Extension} describing the currency of an
+	 *         {@link Identifier}.
+	 */
+	public static Extension createIdentifierCurrencyExtension(CurrencyIdentifier currencyIdentifier) {
+		String system = TransformerConstants.CODING_SYSTEM_IDENTIFIER_CURRENCY;
+		String code = "historic";
+		String display = "Historic";
+		if (currencyIdentifier.equals(CurrencyIdentifier.CURRENT)) {
+			code = "current";
+			display = "Current";
+		}
+
+		Coding currentValueCoding = new Coding(system, code, display);
+		Extension currencyIdentifierExtension = new Extension(TransformerConstants.CODING_SYSTEM_IDENTIFIER_CURRENCY,
+				currentValueCoding);
+
+		return currencyIdentifierExtension;
 	}
 }

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExtraParamsInterceptor.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/ExtraParamsInterceptor.java
@@ -1,0 +1,36 @@
+package gov.hhs.cms.bluebutton.server.app.stu3.providers;
+
+import java.io.IOException;
+
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.client.api.IClientInterceptor;
+import ca.uhn.fhir.rest.client.api.IHttpRequest;
+import ca.uhn.fhir.rest.client.api.IHttpResponse;
+import gov.hhs.cms.bluebutton.server.app.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
+
+/**
+ * An interceptor class to add headers to requests for supplying additional
+ * parameters to FHIR "read" operations. The operation only allows for certain
+ * parameters to be sent (e.g. {@link RequestDetails}) so we add headers with
+ * our own parameters to the request in order to make use of them.
+ */
+public class ExtraParamsInterceptor implements IClientInterceptor {
+
+	private IncludeIdentifiersMode includeIdentifiersMode = IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS;
+
+	@Override
+	public void interceptRequest(IHttpRequest theRequest) {
+		if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS)
+			theRequest.addHeader(IncludeIdentifiersMode.HEADER_NAME_INCLUDE_IDENTIFIERS, Boolean.TRUE.toString());
+	}
+
+	@Override
+	public void interceptResponse(IHttpResponse theResponse) throws IOException {
+		// TODO Auto-generated method stub
+
+	}
+
+	public void setIncludeIdentifiers(IncludeIdentifiersMode includeIdentifiersMode) {
+		this.includeIdentifiersMode = includeIdentifiersMode;
+	}
+}

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProviderIT.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProviderIT.java
@@ -1,9 +1,11 @@
 package gov.hhs.cms.bluebutton.server.app.stu3.providers;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 
 import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.junit.After;
 import org.junit.Assert;
@@ -16,6 +18,7 @@ import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistory;
 import gov.hhs.cms.bluebutton.data.model.rif.samples.StaticRifResourceGroup;
 import gov.hhs.cms.bluebutton.server.app.ServerTestUtils;
+import gov.hhs.cms.bluebutton.server.app.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 
 /**
  * Integration tests for {@link PatientResourceProvider}.
@@ -38,6 +41,84 @@ public final class PatientResourceProviderIT {
 
 		Assert.assertNotNull(patient);
 		BeneficiaryTransformerTest.assertMatches(beneficiary, patient);
+	}
+
+	/**
+	 * Verifies that
+	 * {@link PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)} works
+	 * as expected for a {@link Patient} that does exist in the DB.
+	 */
+	@Test
+	public void readExistingPatientIncludeIdentifiersTrue() {
+		List<Object> loadedRecords = ServerTestUtils
+				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+		fhirClient.registerInterceptor(extraParamsInterceptor);
+
+		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
+				.findFirst().get();
+		Patient patient = fhirClient.read().resource(Patient.class).withId(beneficiary.getBeneficiaryId()).execute();
+
+		Assert.assertNotNull(patient);
+		BeneficiaryTransformerTest.assertMatches(beneficiary, patient);
+
+		/*
+		 * Ensure the unhashed values for HICN and MBI are present.
+		 */
+		Boolean hicnUnhashedPresent = false;
+		Boolean mbiUnhashedPresent = false;
+		Iterator<Identifier> identifiers = patient.getIdentifier().iterator();
+		while (identifiers.hasNext()) {
+			Identifier identifier = identifiers.next();
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED))
+				hicnUnhashedPresent = true;
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED))
+				mbiUnhashedPresent = true;
+		}
+
+		Assert.assertTrue(hicnUnhashedPresent);
+		Assert.assertTrue(mbiUnhashedPresent);
+	}
+
+	/**
+	 * Verifies that
+	 * {@link PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)} works
+	 * as expected for a {@link Patient} that does exist in the DB.
+	 */
+	@Test
+	public void readExistingPatientIncludeIdentifiersFalse() {
+		List<Object> loadedRecords = ServerTestUtils
+				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+		fhirClient.registerInterceptor(extraParamsInterceptor);
+
+		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
+				.findFirst().get();
+		Patient patient = fhirClient.read().resource(Patient.class).withId(beneficiary.getBeneficiaryId()).execute();
+
+		Assert.assertNotNull(patient);
+		BeneficiaryTransformerTest.assertMatches(beneficiary, patient);
+
+		/*
+		 * Ensure the unhashed values for HICN and MBI are *not* present.
+		 */
+		Boolean hicnUnhashedPresent = false;
+		Boolean mbiUnhashedPresent = false;
+		Iterator<Identifier> identifiers = patient.getIdentifier().iterator();
+		while (identifiers.hasNext()) {
+			Identifier identifier = identifiers.next();
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED))
+				hicnUnhashedPresent = true;
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED))
+				mbiUnhashedPresent = true;
+		}
+
+		Assert.assertFalse(hicnUnhashedPresent);
+		Assert.assertFalse(mbiUnhashedPresent);
 	}
 
 	/**
@@ -83,6 +164,90 @@ public final class PatientResourceProviderIT {
 		Assert.assertEquals(1, searchResults.getTotal());
 		Patient patientFromSearchResult = (Patient) searchResults.getEntry().get(0).getResource();
 		BeneficiaryTransformerTest.assertMatches(beneficiary, patientFromSearchResult);
+	}
+
+	/**
+	 * Verifies that
+	 * {@link PatientResourceProvider#searchByLogicalId(ca.uhn.fhir.rest.param.TokenParam)}
+	 * works as expected for a {@link Patient} that does exist in the DB, including
+	 * identifiers to return the unhashed HICN and MBI.
+	 */
+	@Test
+	public void searchForExistingPatientByLogicalIdIncludeIdentifiersTrue() {
+		List<Object> loadedRecords = ServerTestUtils
+				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+		fhirClient.registerInterceptor(extraParamsInterceptor);
+
+		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
+				.findFirst().get();
+		Bundle searchResults = fhirClient.search().forResource(Patient.class)
+				.where(Patient.RES_ID.exactly().systemAndIdentifier(null, beneficiary.getBeneficiaryId()))
+				.returnBundle(Bundle.class).execute();
+
+		Assert.assertNotNull(searchResults);
+		Patient patientFromSearchResult = (Patient) searchResults.getEntry().get(0).getResource();
+
+		/*
+		 * Ensure the unhashed values for HICN and MBI are present.
+		 */
+		Boolean hicnUnhashedPresent = false;
+		Boolean mbiUnhashedPresent = false;
+		Iterator<Identifier> identifiers = patientFromSearchResult.getIdentifier().iterator();
+		while (identifiers.hasNext()) {
+			Identifier identifier = identifiers.next();
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED))
+				hicnUnhashedPresent = true;
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED))
+				mbiUnhashedPresent = true;
+		}
+
+		Assert.assertTrue(hicnUnhashedPresent);
+		Assert.assertTrue(mbiUnhashedPresent);
+	}
+
+	/**
+	 * Verifies that
+	 * {@link PatientResourceProvider#searchByLogicalId(ca.uhn.fhir.rest.param.TokenParam)}
+	 * works as expected for a {@link Patient} that does exist in the DB, including
+	 * identifiers to return the unhashed HICN and MBI.
+	 */
+	@Test
+	public void searchForExistingPatientByLogicalIdIncludeIdentifiersFalse() {
+		List<Object> loadedRecords = ServerTestUtils
+				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+		fhirClient.registerInterceptor(extraParamsInterceptor);
+
+		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
+				.findFirst().get();
+		Bundle searchResults = fhirClient.search().forResource(Patient.class)
+				.where(Patient.RES_ID.exactly().systemAndIdentifier(null, beneficiary.getBeneficiaryId()))
+				.returnBundle(Bundle.class).execute();
+
+		Assert.assertNotNull(searchResults);
+		Patient patientFromSearchResult = (Patient) searchResults.getEntry().get(0).getResource();
+
+		/*
+		 * Ensure the unhashed values for HICN and MBI are *not* present.
+		 */
+		Boolean hicnUnhashedPresent = false;
+		Boolean mbiUnhashedPresent = false;
+		Iterator<Identifier> identifiers = patientFromSearchResult.getIdentifier().iterator();
+		while (identifiers.hasNext()) {
+			Identifier identifier = identifiers.next();
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED))
+				hicnUnhashedPresent = true;
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED))
+				mbiUnhashedPresent = true;
+		}
+
+		Assert.assertFalse(hicnUnhashedPresent);
+		Assert.assertFalse(mbiUnhashedPresent);
 	}
 
 	/**
@@ -164,6 +329,92 @@ public final class PatientResourceProviderIT {
 		Assert.assertEquals(1, searchResults.getTotal());
 		Patient patientFromSearchResult = (Patient) searchResults.getEntry().get(0).getResource();
 		BeneficiaryTransformerTest.assertMatches(beneficiary, patientFromSearchResult);
+	}
+
+	/**
+	 * Verifies that
+	 * {@link PatientResourceProvider#searchByIdentifier(ca.uhn.fhir.rest.param.TokenParam)}
+	 * works as expected for a {@link Patient} that does exist in the DB, including
+	 * identifiers to return the unhashed HICN and MBI.
+	 */
+	@Test
+	public void searchForExistingPatientByHicnHashIncludeIdentifiersTrue() {
+		List<Object> loadedRecords = ServerTestUtils
+				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+		fhirClient.registerInterceptor(extraParamsInterceptor);
+
+		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
+				.findFirst().get();
+		Bundle searchResults = fhirClient.search().forResource(Patient.class)
+				.where(Patient.IDENTIFIER.exactly()
+						.systemAndIdentifier(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH, beneficiary.getHicn()))
+				.returnBundle(Bundle.class).execute();
+
+		Assert.assertNotNull(searchResults);
+		Patient patientFromSearchResult = (Patient) searchResults.getEntry().get(0).getResource();
+
+		/*
+		 * Ensure the unhashed values for HICN and MBI are present.
+		 */
+		Boolean hicnUnhashedPresent = false;
+		Boolean mbiUnhashedPresent = false;
+		Iterator<Identifier> identifiers = patientFromSearchResult.getIdentifier().iterator();
+		while (identifiers.hasNext()) {
+			Identifier identifier = identifiers.next();
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED))
+				hicnUnhashedPresent = true;
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED))
+				mbiUnhashedPresent = true;
+		}
+
+		Assert.assertTrue(hicnUnhashedPresent);
+		Assert.assertTrue(mbiUnhashedPresent);
+	}
+
+	/**
+	 * Verifies that
+	 * {@link PatientResourceProvider#searchByIdentifier(ca.uhn.fhir.rest.param.TokenParam)}
+	 * works as expected for a {@link Patient} that does exist in the DB, including
+	 * identifiers to return the unhashed HICN and MBI.
+	 */
+	@Test
+	public void searchForExistingPatientByHicnHashIncludeIdentifiersFalse() {
+		List<Object> loadedRecords = ServerTestUtils
+				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.OMIT_HICNS_AND_MBIS);
+		fhirClient.registerInterceptor(extraParamsInterceptor);
+
+		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
+				.findFirst().get();
+		Bundle searchResults = fhirClient.search().forResource(Patient.class)
+				.where(Patient.IDENTIFIER.exactly()
+						.systemAndIdentifier(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH, beneficiary.getHicn()))
+				.returnBundle(Bundle.class).execute();
+
+		Assert.assertNotNull(searchResults);
+		Patient patientFromSearchResult = (Patient) searchResults.getEntry().get(0).getResource();
+
+		/*
+		 * Ensure the unhashed values for HICN and MBI are *not* present.
+		 */
+		Boolean hicnUnhashedPresent = false;
+		Boolean mbiUnhashedPresent = false;
+		Iterator<Identifier> identifiers = patientFromSearchResult.getIdentifier().iterator();
+		while (identifiers.hasNext()) {
+			Identifier identifier = identifiers.next();
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED))
+				hicnUnhashedPresent = true;
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED))
+				mbiUnhashedPresent = true;
+		}
+
+		Assert.assertFalse(hicnUnhashedPresent);
+		Assert.assertFalse(mbiUnhashedPresent);
 	}
 
 	/**

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/utils/EndpointJsonResponseComparatorIT.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/utils/EndpointJsonResponseComparatorIT.java
@@ -353,7 +353,7 @@ public final class EndpointJsonResponseComparatorIT {
 		JsonInterceptor jsonInterceptor = createAndRegisterJsonInterceptor(fhirClient);
 
 		fhirClient.read().resource(Patient.class).withId(beneficiary.getBeneficiaryId()).execute();
-		return jsonInterceptor.getResponse();
+		return sortPatientIdentifiers(jsonInterceptor.getResponse());
 	}
 
 	/**
@@ -396,7 +396,7 @@ public final class EndpointJsonResponseComparatorIT {
 		fhirClient.search().forResource(Patient.class)
 				.where(Patient.RES_ID.exactly().systemAndIdentifier(null, beneficiary.getBeneficiaryId()))
 				.returnBundle(Bundle.class).execute();
-		return jsonInterceptor.getResponse();
+		return sortPatientIdentifiers(jsonInterceptor.getResponse());
 	}
 
 	/**
@@ -442,7 +442,7 @@ public final class EndpointJsonResponseComparatorIT {
 				.where(Patient.IDENTIFIER.exactly()
 						.systemAndIdentifier(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH, beneficiary.getHicn()))
 				.returnBundle(Bundle.class).execute();
-		return jsonInterceptor.getResponse();
+		return sortPatientIdentifiers(jsonInterceptor.getResponse());
 	}
 
 	/**

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/utils/EndpointJsonResponseComparatorIT.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/utils/EndpointJsonResponseComparatorIT.java
@@ -20,6 +20,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.hibernate.internal.SessionFactoryRegistry;
 import org.hl7.fhir.dstu3.model.Bundle;
@@ -59,8 +60,10 @@ import gov.hhs.cms.bluebutton.server.app.ServerTestUtils;
 import gov.hhs.cms.bluebutton.server.app.stu3.providers.ClaimType;
 import gov.hhs.cms.bluebutton.server.app.stu3.providers.CoverageResourceProvider;
 import gov.hhs.cms.bluebutton.server.app.stu3.providers.ExplanationOfBenefitResourceProvider;
+import gov.hhs.cms.bluebutton.server.app.stu3.providers.ExtraParamsInterceptor;
 import gov.hhs.cms.bluebutton.server.app.stu3.providers.MedicareSegment;
 import gov.hhs.cms.bluebutton.server.app.stu3.providers.PatientResourceProvider;
+import gov.hhs.cms.bluebutton.server.app.stu3.providers.PatientResourceProvider.IncludeIdentifiersMode;
 import gov.hhs.cms.bluebutton.server.app.stu3.providers.TransformerConstants;
 import gov.hhs.cms.bluebutton.server.app.stu3.providers.TransformerUtils;
 
@@ -76,8 +79,14 @@ public final class EndpointJsonResponseComparatorIT {
 	public static Object[][] data() {
 		return new Object[][] { { "metadata", (Supplier<String>) EndpointJsonResponseComparatorIT::metadata },
 				{ "patientRead", (Supplier<String>) EndpointJsonResponseComparatorIT::patientRead },
+				{ "patientReadWithIncludeIdentifiers",
+						(Supplier<String>) EndpointJsonResponseComparatorIT::patientReadWithIncludeIdentifiers },
 				{ "patientSearchById", (Supplier<String>) EndpointJsonResponseComparatorIT::patientSearchById },
+				{ "patientSearchByIdWithIncludeIdentifiers",
+						(Supplier<String>) EndpointJsonResponseComparatorIT::patientSearchByIdWithIncludeIdentifiers },
 				{ "patientByIdentifier", (Supplier<String>) EndpointJsonResponseComparatorIT::patientByIdentifier },
+				{ "patientByIdentifierWithIncludeIdentifiers",
+						(Supplier<String>) EndpointJsonResponseComparatorIT::patientByIdentifierWithIncludeIdentifiers },
 				{ "coverageRead", (Supplier<String>) EndpointJsonResponseComparatorIT::coverageRead },
 				{ "coverageSearchByPatientId",
 						(Supplier<String>) EndpointJsonResponseComparatorIT::coverageSearchByPatientId },
@@ -349,6 +358,29 @@ public final class EndpointJsonResponseComparatorIT {
 
 	/**
 	 * @return the results of the
+	 *         {@link PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)}
+	 *         operation when
+	 *         {@link ExtraParamsInterceptor#setIncludeIdentifiers(IncludeIdentifiersMode)}
+	 *         set to {@link IncludeIdentifiersMode#INCLUDE_HICNS_AND_MBIS}
+	 */
+	public static String patientReadWithIncludeIdentifiers() {
+		List<Object> loadedRecords = ServerTestUtils
+				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
+				.findFirst().get();
+
+		IGenericClient fhirClient = createFhirClientAndSetEncoding();
+		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+		fhirClient.registerInterceptor(extraParamsInterceptor);
+		JsonInterceptor jsonInterceptor = createAndRegisterJsonInterceptor(fhirClient);
+
+		fhirClient.read().resource(Patient.class).withId(beneficiary.getBeneficiaryId()).execute();
+		return sortPatientIdentifiers(jsonInterceptor.getResponse());
+	}
+
+	/**
+	 * @return the results of the
 	 *         {@link PatientResourceProvider#searchByLogicalId(ca.uhn.fhir.rest.param.TokenParam)}
 	 *         operation
 	 */
@@ -365,6 +397,31 @@ public final class EndpointJsonResponseComparatorIT {
 				.where(Patient.RES_ID.exactly().systemAndIdentifier(null, beneficiary.getBeneficiaryId()))
 				.returnBundle(Bundle.class).execute();
 		return jsonInterceptor.getResponse();
+	}
+
+	/**
+	 * @return the results of the
+	 *         {@link PatientResourceProvider#searchByLogicalId(ca.uhn.fhir.rest.param.TokenParam)}
+	 *         operation when
+	 *         {@link ExtraParamsInterceptor#setIncludeIdentifiers(IncludeIdentifiersMode)}
+	 *         set to {@link IncludeIdentifiersMode#INCLUDE_HICNS_AND_MBIS}
+	 */
+	public static String patientSearchByIdWithIncludeIdentifiers() {
+		List<Object> loadedRecords = ServerTestUtils
+				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
+				.findFirst().get();
+
+		IGenericClient fhirClient = createFhirClientAndSetEncoding();
+		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+		fhirClient.registerInterceptor(extraParamsInterceptor);
+		JsonInterceptor jsonInterceptor = createAndRegisterJsonInterceptor(fhirClient);
+
+		fhirClient.search().forResource(Patient.class)
+				.where(Patient.RES_ID.exactly().systemAndIdentifier(null, beneficiary.getBeneficiaryId()))
+				.returnBundle(Bundle.class).execute();
+		return sortPatientIdentifiers(jsonInterceptor.getResponse());
 	}
 
 	/**
@@ -387,6 +444,98 @@ public final class EndpointJsonResponseComparatorIT {
 				.returnBundle(Bundle.class).execute();
 		return jsonInterceptor.getResponse();
 	}
+
+	/**
+	 * @return the results of the
+	 *         {@link PatientResourceProvider#searchByIdentifier(ca.uhn.fhir.rest.param.TokenParam)}
+	 *         operation when
+	 *         {@link ExtraParamsInterceptor#setIncludeIdentifiers(IncludeIdentifiersMode)}
+	 *         set to {@link IncludeIdentifiersMode#INCLUDE_HICNS_AND_MBIS}
+	 */
+	public static String patientByIdentifierWithIncludeIdentifiers() {
+		List<Object> loadedRecords = ServerTestUtils
+				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
+				.findFirst().get();
+
+		IGenericClient fhirClient = createFhirClientAndSetEncoding();
+		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+		fhirClient.registerInterceptor(extraParamsInterceptor);
+		JsonInterceptor jsonInterceptor = createAndRegisterJsonInterceptor(fhirClient);
+
+		fhirClient.search().forResource(Patient.class)
+				.where(Patient.IDENTIFIER.exactly()
+						.systemAndIdentifier(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH, beneficiary.getHicn()))
+				.returnBundle(Bundle.class).execute();
+		return sortPatientIdentifiers(jsonInterceptor.getResponse());
+	}
+
+	/**
+	 * @param unsortedResponse the JSON to fix up
+	 * @return the same JSON, but with the contents of
+	 *         <code>Patient.identifiers</code> sorted
+	 */
+	private static String sortPatientIdentifiers(String unsortedResponse) {
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.writerWithDefaultPrettyPrinter();
+		JsonNode parsedJson = null;
+		try {
+			parsedJson = mapper.readTree(unsortedResponse);
+		} catch (IOException e) {
+			throw new UncheckedIOException(
+					"Unable to deserialize the following JSON content as tree: " + unsortedResponse, e);
+		}
+
+		// Is this a Bundle or a single Patient? If a Bundle, grab the (single) Patient
+		// from it.
+		JsonNode rootResourceType = parsedJson.at("/resourceType");
+		JsonNode patient;
+		if(rootResourceType.asText().equals("Patient")) {
+			patient = parsedJson;
+		} else if (rootResourceType.asText().equals("Bundle")) {
+			JsonNode entries = parsedJson.at("/entry");
+			Assert.assertEquals(1, entries.size());
+			patient = entries.at("/0/resource");
+			Assert.assertEquals("Patient", patient.get("resourceType").asText());
+		} else {
+			throw new IllegalArgumentException("Unsupported resourceType: " + rootResourceType.asText());
+		}
+
+		// Grab the Patient.identifiers node.
+		JsonNode identifiers = patient.at("/identifier");
+
+		// Pull out an unsorted List all of the identifier entries.
+		List<JsonNode> identiferEntries = new ArrayList<JsonNode>();
+		identifiers.elements().forEachRemaining(identiferEntries::add);
+
+		/*
+		 * Sort that List of identifier entries in a stable fashion: first, compare
+		 * identifier.system, then identifier.value, then (if present) identifier.extension[0].valueCoding.code.
+		 */
+		Comparator<JsonNode> systemComparator = Comparator.comparing(e -> e.at("/system").asText());
+		Comparator<JsonNode> valueComparator = Comparator.comparing(e -> e.at("/value").asText());
+		Comparator<JsonNode> codeComparator = Comparator.comparing(e -> e.at("/extension/0/valueCoding/code").asText());
+		Comparator<JsonNode> identifiersComparator = systemComparator.thenComparing(valueComparator)
+				.thenComparing(codeComparator);
+		identiferEntries = identiferEntries.stream().sorted(identifiersComparator)
+				.collect(Collectors.toList());
+
+		((ArrayNode) identifiers).removeAll();
+		for (int i = 0; i < identiferEntries.size(); i++) {
+			((ArrayNode) identifiers).add(identiferEntries.get(i));
+		}
+
+		String jsonResponse = null;
+		try {
+			jsonResponse = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(parsedJson);
+		} catch (JsonProcessingException e) {
+			throw new UncheckedIOException(
+					"Unable to deserialize the following JSON content as tree: " + unsortedResponse, e);
+		}
+		return jsonResponse;
+	}
+
 
 	/**
 	 * @return the results of the

--- a/bluebutton-server-app/src/test/resources/endpoint-responses/patientByIdentifier.json
+++ b/bluebutton-server-app/src/test/resources/endpoint-responses/patientByIdentifier.json
@@ -110,11 +110,11 @@
         }
       } ],
       "identifier" : [ {
-        "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
-        "value" : "567834"
-      }, {
         "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
         "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
+      }, {
+        "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
+        "value" : "567834"
       } ],
       "name" : [ {
         "use" : "usual",

--- a/bluebutton-server-app/src/test/resources/endpoint-responses/patientByIdentifierWithIncludeIdentifiers.json
+++ b/bluebutton-server-app/src/test/resources/endpoint-responses/patientByIdentifierWithIncludeIdentifiers.json
@@ -1,0 +1,188 @@
+{
+  "resourceType" : "Bundle",
+  "id" : "IGNORED_FIELD",
+  "meta" : {
+    "lastUpdated" : "IGNORED_FIELD"
+  },
+  "type" : "searchset",
+  "total" : 1,
+  "link" : [ {
+    "relation" : "self",
+    "url" : "https://localhost:IGNORED_FIELD/v1/fhir/Patient?_format=json&identifier=https%3A%2F%2Fbluebutton.cms.gov%2Fresources%2Fidentifier%2Fhicn-hash%7C99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
+  } ],
+  "entry" : [ {
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "567834",
+      "extension" : [ {
+        "url" : "https://bluebutton.cms.gov/resources/variables/race",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/race",
+          "code" : "1",
+          "display" : "White"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/rfrnc_yr",
+        "valueDate" : "2019"
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_01",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_01",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_02",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_02",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_03",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_03",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_04",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_04",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_05",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_05",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_06",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_06",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_07",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_07",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_08",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_08",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_09",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_09",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_10",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_10",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_11",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_11",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_12",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_12",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding" : {
+            "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code" : "current",
+            "display" : "Current"
+          }
+        } ],
+        "system" : "http://hl7.org/fhir/sid/us-mbi",
+        "value" : "3456789"
+      }, {
+        "extension" : [ {
+          "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding" : {
+            "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code" : "historic",
+            "display" : "Historic"
+          }
+        } ],
+        "system" : "http://hl7.org/fhir/sid/us-mbi",
+        "value" : "9AB2WW3GR44"
+      }, {
+        "extension" : [ {
+          "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding" : {
+            "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code" : "historic",
+            "display" : "Historic"
+          }
+        } ],
+        "system" : "http://hl7.org/fhir/sid/us-medicare",
+        "value" : "543217066T"
+      }, {
+        "extension" : [ {
+          "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding" : {
+            "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code" : "current",
+            "display" : "Current"
+          }
+        } ],
+        "system" : "http://hl7.org/fhir/sid/us-medicare",
+        "value" : "543217066U"
+      }, {
+        "extension" : [ {
+          "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding" : {
+            "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code" : "historic",
+            "display" : "Historic"
+          }
+        } ],
+        "system" : "http://hl7.org/fhir/sid/us-medicare",
+        "value" : "543217066Z"
+      }, {
+        "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
+        "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
+      }, {
+        "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
+        "value" : "567834"
+      } ],
+      "name" : [ {
+        "use" : "usual",
+        "family" : "Doe",
+        "given" : [ "John", "A" ]
+      } ],
+      "gender" : "male",
+      "birthDate" : "1981-03-17",
+      "address" : [ {
+        "district" : "123",
+        "state" : "MO",
+        "postalCode" : "12345"
+      } ]
+    }
+  } ]
+}

--- a/bluebutton-server-app/src/test/resources/endpoint-responses/patientRead.json
+++ b/bluebutton-server-app/src/test/resources/endpoint-responses/patientRead.json
@@ -97,11 +97,11 @@
     }
   } ],
   "identifier" : [ {
-    "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
-    "value" : "567834"
-  }, {
     "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
     "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
+  }, {
+    "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
+    "value" : "567834"
   } ],
   "name" : [ {
     "use" : "usual",

--- a/bluebutton-server-app/src/test/resources/endpoint-responses/patientReadWithIncludeIdentifiers.json
+++ b/bluebutton-server-app/src/test/resources/endpoint-responses/patientReadWithIncludeIdentifiers.json
@@ -1,0 +1,173 @@
+{
+  "resourceType" : "Patient",
+  "id" : "567834",
+  "extension" : [ {
+    "url" : "https://bluebutton.cms.gov/resources/variables/race",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/race",
+      "code" : "1",
+      "display" : "White"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/rfrnc_yr",
+    "valueDate" : "2019"
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_01",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_01",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_02",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_02",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_03",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_03",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_04",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_04",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_05",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_05",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_06",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_06",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_07",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_07",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_08",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_08",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_09",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_09",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_10",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_10",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_11",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_11",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  }, {
+    "url" : "https://bluebutton.cms.gov/resources/variables/dual_12",
+    "valueCoding" : {
+      "system" : "https://bluebutton.cms.gov/resources/variables/dual_12",
+      "code" : "**",
+      "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+    }
+  } ],
+  "identifier" : [ {
+    "extension" : [ {
+      "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+      "valueCoding" : {
+        "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+        "code" : "current",
+        "display" : "Current"
+      }
+    } ],
+    "system" : "http://hl7.org/fhir/sid/us-mbi",
+    "value" : "3456789"
+  }, {
+    "extension" : [ {
+      "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+      "valueCoding" : {
+        "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+        "code" : "historic",
+        "display" : "Historic"
+      }
+    } ],
+    "system" : "http://hl7.org/fhir/sid/us-mbi",
+    "value" : "9AB2WW3GR44"
+  }, {
+    "extension" : [ {
+      "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+      "valueCoding" : {
+        "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+        "code" : "historic",
+        "display" : "Historic"
+      }
+    } ],
+    "system" : "http://hl7.org/fhir/sid/us-medicare",
+    "value" : "543217066T"
+  }, {
+    "extension" : [ {
+      "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+      "valueCoding" : {
+        "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+        "code" : "current",
+        "display" : "Current"
+      }
+    } ],
+    "system" : "http://hl7.org/fhir/sid/us-medicare",
+    "value" : "543217066U"
+  }, {
+    "extension" : [ {
+      "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+      "valueCoding" : {
+        "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+        "code" : "historic",
+        "display" : "Historic"
+      }
+    } ],
+    "system" : "http://hl7.org/fhir/sid/us-medicare",
+    "value" : "543217066Z"
+  }, {
+    "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
+    "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
+  }, {
+    "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
+    "value" : "567834"
+  } ],
+  "name" : [ {
+    "use" : "usual",
+    "family" : "Doe",
+    "given" : [ "John", "A" ]
+  } ],
+  "gender" : "male",
+  "birthDate" : "1981-03-17",
+  "address" : [ {
+    "district" : "123",
+    "state" : "MO",
+    "postalCode" : "12345"
+  } ]
+}

--- a/bluebutton-server-app/src/test/resources/endpoint-responses/patientSearchById.json
+++ b/bluebutton-server-app/src/test/resources/endpoint-responses/patientSearchById.json
@@ -110,11 +110,11 @@
         }
       } ],
       "identifier" : [ {
-        "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
-        "value" : "567834"
-      }, {
         "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
         "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
+      }, {
+        "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
+        "value" : "567834"
       } ],
       "name" : [ {
         "use" : "usual",

--- a/bluebutton-server-app/src/test/resources/endpoint-responses/patientSearchByIdWithIncludeIdentifiers.json
+++ b/bluebutton-server-app/src/test/resources/endpoint-responses/patientSearchByIdWithIncludeIdentifiers.json
@@ -1,0 +1,188 @@
+{
+  "resourceType" : "Bundle",
+  "id" : "IGNORED_FIELD",
+  "meta" : {
+    "lastUpdated" : "IGNORED_FIELD"
+  },
+  "type" : "searchset",
+  "total" : 1,
+  "link" : [ {
+    "relation" : "self",
+    "url" : "https://localhost:IGNORED_FIELD/v1/fhir/Patient?_format=json&_id=%7C567834"
+  } ],
+  "entry" : [ {
+    "resource" : {
+      "resourceType" : "Patient",
+      "id" : "567834",
+      "extension" : [ {
+        "url" : "https://bluebutton.cms.gov/resources/variables/race",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/race",
+          "code" : "1",
+          "display" : "White"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/rfrnc_yr",
+        "valueDate" : "2019"
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_01",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_01",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_02",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_02",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_03",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_03",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_04",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_04",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_05",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_05",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_06",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_06",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_07",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_07",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_08",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_08",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_09",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_09",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_10",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_10",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_11",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_11",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      }, {
+        "url" : "https://bluebutton.cms.gov/resources/variables/dual_12",
+        "valueCoding" : {
+          "system" : "https://bluebutton.cms.gov/resources/variables/dual_12",
+          "code" : "**",
+          "display" : "Enrolled in Medicare A and/or B, but no Part D enrollment data for the beneficiary. (This status was indicated as 'XX' for 2006-2009)"
+        }
+      } ],
+      "identifier" : [ {
+        "extension" : [ {
+          "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding" : {
+            "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code" : "current",
+            "display" : "Current"
+          }
+        } ],
+        "system" : "http://hl7.org/fhir/sid/us-mbi",
+        "value" : "3456789"
+      }, {
+        "extension" : [ {
+          "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding" : {
+            "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code" : "historic",
+            "display" : "Historic"
+          }
+        } ],
+        "system" : "http://hl7.org/fhir/sid/us-mbi",
+        "value" : "9AB2WW3GR44"
+      }, {
+        "extension" : [ {
+          "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding" : {
+            "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code" : "historic",
+            "display" : "Historic"
+          }
+        } ],
+        "system" : "http://hl7.org/fhir/sid/us-medicare",
+        "value" : "543217066T"
+      }, {
+        "extension" : [ {
+          "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding" : {
+            "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code" : "current",
+            "display" : "Current"
+          }
+        } ],
+        "system" : "http://hl7.org/fhir/sid/us-medicare",
+        "value" : "543217066U"
+      }, {
+        "extension" : [ {
+          "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding" : {
+            "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code" : "historic",
+            "display" : "Historic"
+          }
+        } ],
+        "system" : "http://hl7.org/fhir/sid/us-medicare",
+        "value" : "543217066Z"
+      }, {
+        "system" : "https://bluebutton.cms.gov/resources/identifier/hicn-hash",
+        "value" : "99f6cc85e95c4b2cec5382600478482cceadb7534d4c3f0a4f2e55d33428c169"
+      }, {
+        "system" : "https://bluebutton.cms.gov/resources/variables/bene_id",
+        "value" : "567834"
+      } ],
+      "name" : [ {
+        "use" : "usual",
+        "family" : "Doe",
+        "given" : [ "John", "A" ]
+      } ],
+      "gender" : "male",
+      "birthDate" : "1981-03-17",
+      "address" : [ {
+        "district" : "123",
+        "state" : "MO",
+        "postalCode" : "12345"
+      } ]
+    }
+  } ]
+}

--- a/dev/api-changelog.md
+++ b/dev/api-changelog.md
@@ -1,5 +1,38 @@
 # API Changelog
 
+## BLUEBUTTON-865: Adding plaintext HICN/MBI to Patient resource
+
+The Patient resource will now return plaintext HICN/MBI (both current and historical) values when a BCDA-only header (IncludeIdentifiers) is included in the request. The added fields will look like:
+
+	'''{
+      "extension": [
+        {
+          "url": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding": {
+            "system": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code": "current",
+            "display": "Current"
+          }
+        }
+      ],
+      "system": "http://hl7.org/fhir/sid/us-medicare",
+      "value": "543217066U"
+    },
+    {
+      "extension": [
+        {
+          "url": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+          "valueCoding": {
+            "system": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+            "code": "current",
+            "display": "Current"
+          }
+        }
+      ],
+      "system": "http://hl7.org/fhir/sid/us-mbi",
+      "value": "3456789"
+    }```
+
 ## BLUEBUTTON-926: Exposing additional beneficiary coverage fields
 
 A number of additional data fields have been added, mostly related to coverage and enrollment:

--- a/dev/api-changelog.md
+++ b/dev/api-changelog.md
@@ -2,36 +2,57 @@
 
 ## BLUEBUTTON-865: Adding plaintext HICN/MBI to Patient resource
 
-The Patient resource will now return plaintext HICN/MBI (both current and historical) values when a BCDA-only header (IncludeIdentifiers) is included in the request. The added fields will look like:
+A new optional flag has been added that will return all of a beneficiary's known HICNs and MBIs (in plaintext, both current and historical).
+This feature is primarily intended for BCDA, whose ACO users need this data for patient matching purposes.
+To enable this, set an "`IncludeIdentifiers: true`" HTTP header in the `/Patient` request.
 
-	'''{
-      "extension": [
-        {
-          "url": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
-          "valueCoding": {
-            "system": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
-            "code": "current",
-            "display": "Current"
-          }
-        }
-      ],
-      "system": "http://hl7.org/fhir/sid/us-medicare",
-      "value": "543217066U"
-    },
-    {
-      "extension": [
-        {
-          "url": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
-          "valueCoding": {
-            "system": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
-            "code": "current",
-            "display": "Current"
-          }
-        }
-      ],
-      "system": "http://hl7.org/fhir/sid/us-mbi",
-      "value": "3456789"
-    }```
+The added fields will look like:
+
+```
+"resource" : {
+  "resourceType" : "Patient",
+  ...
+  "identifier" : [
+  ... ,
+  {
+    "extension" : [ {
+      "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+      "valueCoding" : {
+        "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+        "code" : "current",
+        "display" : "Current"
+      }
+    } ],
+    "system" : "http://hl7.org/fhir/sid/us-medicare",
+    "value" : "543217066U"
+  }, {
+    "extension" : [ {
+      "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+      "valueCoding" : {
+        "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+        "code" : "current",
+        "display" : "Current"
+      }
+    } ],
+    "system" : "http://hl7.org/fhir/sid/us-mbi",
+    "value" : "3456789"
+  }, {
+    "extension" : [ {
+      "url" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+      "valueCoding" : {
+        "system" : "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+        "code" : "historic",
+        "display" : "Historic"
+      }
+    } ],
+    "system" : "http://hl7.org/fhir/sid/us-medicare",
+    "value" : "543217066T"
+  },
+  ...
+  ],
+  ...
+}
+```
 
 ## BLUEBUTTON-926: Exposing additional beneficiary coverage fields
 


### PR DESCRIPTION
This is Round 2 for the changes from this earlier (reverted) PR: https://github.com/CMSgov/bluebutton-data-server/pull/143. Basically, we're adding an option to include plaintext HICNs and MBIs in the `Patient.identifier` results.

Originally, the PR was reverted as it needed a DB index that wasn't present. That index was added in https://github.com/CMSgov/bluebutton-data-model/pull/77, and so this enhancement should now be safe to deploy.

This PR is a revert-of-the-revert, with some additional tweaks:

* Improve performance a bit by going from 3 DB queries down to 1.
* Try harder to not send plaintext HICNs and MBIs to the transformer, when they're not needed.
* Tweak the API changelog a bit.
* Added `EndpointJsonResponseComparatorIT` test cases to cover the new query types.

https://jira.cms.gov/browse/BLUEBUTTON-865

See also: https://jira.cms.gov/browse/BLUEBUTTON-1110