### PR TITLE
BLUEBUTTON-865: Fix IncludeIdentifiers bug causing failed searches

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProvider.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProvider.java
@@ -12,6 +12,7 @@ import javax.persistence.NonUniqueResultException;
 import javax.persistence.PersistenceContext;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
@@ -125,8 +126,8 @@ public final class PatientResourceProvider implements IResourceProvider {
 		if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS) {
 			// For efficiency, grab these relations in the same query.
 			// For security, only grab them when needed.
-			root.fetch(Beneficiary_.beneficiaryHistories);
-			root.fetch(Beneficiary_.medicareBeneficiaryIdHistories);
+			root.fetch(Beneficiary_.beneficiaryHistories, JoinType.LEFT);
+			root.fetch(Beneficiary_.medicareBeneficiaryIdHistories, JoinType.LEFT);
 		}
 		criteria.select(root);
 		criteria.where(builder.equal(root.get(Beneficiary_.beneficiaryId), beneIdText));
@@ -333,8 +334,8 @@ public final class PatientResourceProvider implements IResourceProvider {
 		if (includeIdentifiersMode == IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS) {
 			// For efficiency, grab these relations in the same query.
 			// For security, only grab them when needed.
-			beneMatchesRoot.fetch(Beneficiary_.beneficiaryHistories);
-			beneMatchesRoot.fetch(Beneficiary_.medicareBeneficiaryIdHistories);
+			beneMatchesRoot.fetch(Beneficiary_.beneficiaryHistories, JoinType.LEFT);
+			beneMatchesRoot.fetch(Beneficiary_.medicareBeneficiaryIdHistories, JoinType.LEFT);
 		}
 		beneMatches.select(beneMatchesRoot);
 		Predicate beneHicnMatches = builder.equal(beneMatchesRoot.get(Beneficiary_.hicn), hicnHash);

--- a/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProviderIT.java
+++ b/bluebutton-server-app/src/test/java/gov/hhs/cms/bluebutton/server/app/stu3/providers/PatientResourceProviderIT.java
@@ -16,6 +16,7 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import gov.hhs.cms.bluebutton.data.model.rif.Beneficiary;
 import gov.hhs.cms.bluebutton.data.model.rif.BeneficiaryHistory;
+import gov.hhs.cms.bluebutton.data.model.rif.MedicareBeneficiaryIdHistory;
 import gov.hhs.cms.bluebutton.data.model.rif.samples.StaticRifResource;
 import gov.hhs.cms.bluebutton.data.model.rif.samples.StaticRifResourceGroup;
 import gov.hhs.cms.bluebutton.server.app.ServerTestUtils;
@@ -53,6 +54,46 @@ public final class PatientResourceProviderIT {
 	public void readExistingPatientIncludeIdentifiersTrue() {
 		List<Object> loadedRecords = ServerTestUtils
 				.loadData(Arrays.asList(StaticRifResourceGroup.SAMPLE_A.getResources()));
+		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+		fhirClient.registerInterceptor(extraParamsInterceptor);
+
+		Beneficiary beneficiary = loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r)
+				.findFirst().get();
+		Patient patient = fhirClient.read().resource(Patient.class).withId(beneficiary.getBeneficiaryId()).execute();
+
+		Assert.assertNotNull(patient);
+		BeneficiaryTransformerTest.assertMatches(beneficiary, patient);
+
+		/*
+		 * Ensure the unhashed values for HICN and MBI are present.
+		 */
+		Boolean hicnUnhashedPresent = false;
+		Boolean mbiUnhashedPresent = false;
+		Iterator<Identifier> identifiers = patient.getIdentifier().iterator();
+		while (identifiers.hasNext()) {
+			Identifier identifier = identifiers.next();
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_BENE_HICN_UNHASHED))
+				hicnUnhashedPresent = true;
+			if (identifier.getSystem().equals(TransformerConstants.CODING_BBAPI_MEDICARE_BENEFICIARY_ID_UNHASHED))
+				mbiUnhashedPresent = true;
+		}
+
+		Assert.assertTrue(hicnUnhashedPresent);
+		Assert.assertTrue(mbiUnhashedPresent);
+	}
+
+	/**
+	 * Verifies that
+	 * {@link PatientResourceProvider#read(org.hl7.fhir.dstu3.model.IdType)} works
+	 * as expected for a {@link Patient} that does exist in the DB but has no
+	 * {@link BeneficiaryHistory} or {@link MedicareBeneficiaryIdHistory} records.
+	 */
+	@Test
+	public void readExistingPatientWithNoHistoryIncludeIdentifiersTrue() {
+		List<Object> loadedRecords = ServerTestUtils
+				.loadData(Arrays.asList(StaticRifResource.SAMPLE_A_BENES));
 		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
 		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
 		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
@@ -488,6 +529,33 @@ public final class PatientResourceProviderIT {
 	public void searchForExistingPatientWithNoHistory() {
 		List<Object> loadedRecords = ServerTestUtils.loadData(Arrays.asList(StaticRifResource.SAMPLE_A_BENES));
 		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+
+		loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r).forEach(h -> {
+			Bundle searchResults = fhirClient.search().forResource(Patient.class)
+					.where(Patient.IDENTIFIER.exactly()
+							.systemAndIdentifier(TransformerConstants.CODING_BBAPI_BENE_HICN_HASH, h.getHicn()))
+					.returnBundle(Bundle.class).execute();
+
+			Assert.assertNotNull(searchResults);
+			Assert.assertEquals(1, searchResults.getTotal());
+			Patient patientFromSearchResult = (Patient) searchResults.getEntry().get(0).getResource();
+			Assert.assertEquals(h.getBeneficiaryId(), patientFromSearchResult.getIdElement().getIdPart());
+		});
+	}
+
+	/**
+	 * Verifies that
+	 * {@link PatientResourceProvider#searchByIdentifier(ca.uhn.fhir.rest.param.TokenParam)}
+	 * works as expected for HICNs associated with {@link Beneficiary}s that have
+	 * <strong>no</strong> {@link BeneficiaryHistory} records.
+	 */
+	@Test
+	public void searchForExistingPatientWithNoHistoryIncludeIdentifiersTrue() {
+		List<Object> loadedRecords = ServerTestUtils.loadData(Arrays.asList(StaticRifResource.SAMPLE_A_BENES));
+		IGenericClient fhirClient = ServerTestUtils.createFhirClient();
+		ExtraParamsInterceptor extraParamsInterceptor = new ExtraParamsInterceptor();
+		extraParamsInterceptor.setIncludeIdentifiers(IncludeIdentifiersMode.INCLUDE_HICNS_AND_MBIS);
+		fhirClient.registerInterceptor(extraParamsInterceptor);
 
 		loadedRecords.stream().filter(r -> r instanceof Beneficiary).map(r -> (Beneficiary) r).forEach(h -> {
 			Bundle searchResults = fhirClient.search().forResource(Patient.class)


### PR DESCRIPTION
The default `JoinType` for `fetch(...)` is `INNER`, which causes lookups to fail for any benes that don't have historical ID records -- only when IncludeIdentifiers is enabled.

https://jira.cms.gov/browse/BLUEBUTTON-865